### PR TITLE
Rendering optimization

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,9 @@ build_flags =
     -DUSE_SDL=1
     -DDISABLE_WATCHDOGS
     ;-DFRAMESKIP ; Enable frameskip, turned off for smoother performance
-    ; -DNGP_INTERLACED ; Enable interlaced rendering mode
+    ;-DNGP_INTERLACED ; Enable interlaced rendering mode for display output
+    -DNGP_ONLY_RENDER_VISIBLE_LINES ; Disbales rendering of lines that arent visible due to scaling
+    ;-DNGP_HW_INTERLACED ; Skip every other line that would normally be rendered by the emulator
     -DNGP_OPTIMIZATION_16BIT_READ ; 16-bit reads with alignment check for native bus transactions
 
     ; GWENESIS

--- a/src/ngp/ngc_display.cpp
+++ b/src/ngp/ngc_display.cpp
@@ -23,6 +23,9 @@ static uint16_t* s_lut_x_full    = nullptr;
 static uint16_t* s_lut_y_full    = nullptr;
 static uint16_t* s_lut_x_4x3     = nullptr;
 static uint16_t* s_fb            = nullptr;
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+uint8_t* s_lut_y_render    = nullptr; // 152 element array of boolean render status for each line
+#endif
 unsigned short *drawBuffer = s_fb; 
 
 extern "C" void ngc_display_init(void)
@@ -53,6 +56,12 @@ extern "C" void ngc_display_init(void)
   if (!s_lut_x_4x3)
     s_lut_x_4x3 = (uint16_t*)heap_caps_malloc(180 * sizeof(uint16_t),
                                               MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+  if (!s_lut_y_render)
+    s_lut_y_render = (uint8_t*)heap_caps_malloc(152 * sizeof(uint8_t),
+                                              MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+#endif
 
   M5.Display.setSwapBytes(true);
   M5.Display.fillScreen(TFT_BLACK);
@@ -90,6 +99,16 @@ static void build_scale_luts()
     int srcX  = virtX - virtOff;
     s_lut_x_4x3[x] = (unsigned)srcX < (unsigned)srcW ? (uint16_t)srcX : 0;
   }
+
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+  // reset all lines to 0
+  for (int y = 0; y < srcH; y++)
+    s_lut_y_render[y]=0;
+
+  // toggle only visible lines
+  for (int y = 0; y < outH; y++)
+    s_lut_y_render[s_lut_y_full[y]]=1;
+#endif
 
   s_lut_ready = true;
 }

--- a/src/ngp/race/tlcs900h.c
+++ b/src/ngp/race/tlcs900h.c
@@ -100,8 +100,9 @@ int ngOverflow = 0;
 #ifdef NGP_HW_INTERLACED
 // Etat frameskip
 static int s_framePatternIdx = 0;
-// Flag render
-static bool s_doRenderThisFrame = true;
+#endif
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+extern uint8_t* s_lut_y_render;
 #endif
 
 //#define USE_PARITY_TABLE  //this is currently broken!
@@ -8345,18 +8346,56 @@ void tlcs_execute(int cycles)
             // If we are skipping frames, only render the last one
             if (s_framesToSkip > 0)
                 renderThisLine = false;
-
+#ifdef NGP_HW_INTERLACED
+            else if (*scanlineY < 152)
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+                if (s_lut_y_render[*scanlineY])
+#endif
+                    s_framePatternIdx ^= 1;          // always alternate when no frameskip
+#endif
 #ifdef NGP_HW_INTERLACED
             else  // only applied if frame is being rendered
-                renderThisLine = s_doRenderThisFrame;
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+                if (s_lut_y_render[*scanlineY])
+#endif
+                renderThisLine = s_framePatternIdx;
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+                else
+                    renderThisLine=false;
+#endif 
 #endif
 #else
 #ifdef NGP_HW_INTERLACED
-            renderThisLine = s_doRenderThisFrame;
+            if (*scanlineY < 152)
+            {
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+                if (s_lut_y_render[*scanlineY])
+#endif
+                    s_framePatternIdx ^= 1;          // always alternate when no frameskip
+
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+                if (s_lut_y_render[*scanlineY]) // only use pattern if this is a visible line
+#endif
+                    renderThisLine = s_framePatternIdx;
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+                else
+                    renderThisLine = false;
+#endif
+            }
+#else
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+            if (*scanlineY < 152)
+                if (!s_lut_y_render[*scanlineY])
+                    renderThisLine = false; // do not render lines that arent visible due to scaling
 #endif
 #endif
+#endif
+            // per-line rendering debug. actual scanlineY values will go up to ~198
+            // if (*scanlineY < 152)
+            //     printf("[NGP_LINE] scanelineY %d | renderThisLine %d | s_framePatternIdx %d | s_lut_y_render[%d]=%d\n",(int)*scanlineY,(int)renderThisLine,s_framePatternIdx,(int)*scanlineY,(int)s_lut_y_render[*scanlineY]);
             myGraphicsBlitLine(renderThisLine);
             hCounter += 515;
+
 
             // HBlank
             if (*scanlineY < 151 || *scanlineY == finscan)
@@ -8377,17 +8416,17 @@ void tlcs_execute(int cycles)
                 else
                 {
 #ifdef NGP_HW_INTERLACED
-                    s_framePatternIdx ^= 1;  // 0/1 alternating only on real frames
-                    s_doRenderThisFrame = (s_framePatternIdx == 0);
-                    s_interlace_parity = s_framePatternIdx; // <-- set parity for draw
+                    s_interlace_parity = s_framePatternIdx; // <-- set parity for draw, if 152 lines than the parity the same as the last line
 #endif
                     s_framesToSkip = skipframe;  // set up next skip cycle
                 }
 #else
-#ifdef NGP_HW_INTERLACED   
-                s_framePatternIdx ^= 1;          // always alternate when no frameskip
-                s_doRenderThisFrame = (s_framePatternIdx == 0);
-                s_interlace_parity = s_framePatternIdx; // <-- set parity for draw
+#ifdef NGP_HW_INTERLACED
+#ifdef NGP_ONLY_RENDER_VISIBLE_LINES
+                s_interlace_parity = s_framePatternIdx^1; // the opposite parity of the current value for odd number of line(135)
+#else
+                s_interlace_parity = s_framePatternIdx; // the current pairty for the draw parity for even number of lines(152)
+#endif
 #endif
 #endif
             }


### PR DESCRIPTION
As discussed, an LUT has been added for which lines are visible after scaling is applied and used to reduce the overall render workload when the NGP_ONLY_RENDER_VISIBLE_LINES flag. Original behaviour has been improved as well with clearer logic and a global variable removed.