### PR TITLE
32-bit read path improvements

### DIFF
--- a/src/ngp/race/race-memory.h
+++ b/src/ngp/race/race-memory.h
@@ -238,12 +238,16 @@ static INLINE unsigned int tlcsMemReadL(unsigned int addr)
    if(gA == 0)
       return 0;
 
-   i = *(gA++);
-   i |= (*(gA++)) << 8;
-   i |= (*(gA++)) << 16;
-   i |= (unsigned int)(*gA) << 24;
+      /* unaligned path */
+   if (((uintptr_t)gA) & 3) {
+      return  (unsigned int)gA[0]
+            | ((unsigned int)gA[1] << 8)
+            | ((unsigned int)gA[2] << 16)
+            | ((unsigned int)gA[3] << 24);
+   }
 
-   return i;
+   /* aligned fast path */
+   return *(const unsigned int *)gA;   
 #endif
 }
 


### PR DESCRIPTION
Effects summary:
Before this update: average 16.0644 ms (metal slug first level) After this update: 15.9167 ms (metal slug first level) Improvement: ~ -0.147 ms/frame

What I did?
When dealing with memory from RAM, the esp32-s3 does not enforce strict aliasing or alignment, but it handles off-boundary cases with microcode which is actually slower than manually checking for alignment.