### PR TITLE
Frame pacing & (not too aggressive) auto-frame skip

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ build_flags =
     -DUSE_SDL=1
     -DDISABLE_WATCHDOGS
     ;-DUSE_PARITY_TABLE ; Existing speed hack for NGP, possible compatibility issues, use at own risk
-    -DFRAMESKIP ; Enable auto-frameskip
+    ;-DFRAMESKIP ; Enable auto-frameskip, this at most can gain 2-3fps while skipping 25% of frames. Large penalty for little gain.
     ;-DNGP_INTERLACED ; Enable interlaced rendering mode for display output
     -DNGP_ONLY_RENDER_VISIBLE_LINES ; Disbales rendering of lines that arent visible due to scaling
     ;-DNGP_HW_INTERLACED ; Skip every other line that would normally be rendered by the emulator

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,8 +37,8 @@ build_flags =
     -DCZ80=1
     -DUSE_SDL=1
     -DDISABLE_WATCHDOGS
-    ;-DUSE_PARITY_TABLE ; Existing speed hack for NGP, possible compatibility issues, use at own risk
-    ;-DFRAMESKIP ; Enable auto-frameskip, this at most can gain 2-3fps while skipping 25% of frames. Large penalty for little gain.
+    -DNGP_USE_THREADED_COLORMAPPING ; Use a separate thread for color mapping to improve performance
+    ;-DFRAMESKIP ; Enable frameskip, turned off for smoother performance
     ;-DNGP_INTERLACED ; Enable interlaced rendering mode for display output
     -DNGP_ONLY_RENDER_VISIBLE_LINES ; Disbales rendering of lines that arent visible due to scaling
     ;-DNGP_HW_INTERLACED ; Skip every other line that would normally be rendered by the emulator

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ build_flags =
     -DUSE_SDL=1
     -DDISABLE_WATCHDOGS
     ;-DUSE_PARITY_TABLE ; Existing speed hack for NGP, possible compatibility issues, use at own risk
-    ;-DFRAMESKIP ; Enable frameskip, turned off for smoother performance
+    -DFRAMESKIP ; Enable auto-frameskip
     ;-DNGP_INTERLACED ; Enable interlaced rendering mode for display output
     -DNGP_ONLY_RENDER_VISIBLE_LINES ; Disbales rendering of lines that arent visible due to scaling
     ;-DNGP_HW_INTERLACED ; Skip every other line that would normally be rendered by the emulator

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,6 +37,7 @@ build_flags =
     -DCZ80=1
     -DUSE_SDL=1
     -DDISABLE_WATCHDOGS
+    ;-DUSE_PARITY_TABLE ; Existing speed hack for NGP, possible compatibility issues, use at own risk
     ;-DFRAMESKIP ; Enable frameskip, turned off for smoother performance
     ;-DNGP_INTERLACED ; Enable interlaced rendering mode for display output
     -DNGP_ONLY_RENDER_VISIBLE_LINES ; Disbales rendering of lines that arent visible due to scaling

--- a/src/ngp/ngc_display.cpp
+++ b/src/ngp/ngc_display.cpp
@@ -178,9 +178,6 @@ static inline void paint_fullscreen_stretch()
   M5.Display.endWrite();
 }
 
-  // To do: This function does not appear to have been updated in a while:
-  // - forced interlacing needs to be replaced with updated s_interlace_parity usage
-  // - color conversion optimization like in paint_fullscreen_stretch(), using line buffer - currently incorrect colours when NGP_USE_THREADED_COLORMAPPING is defined
 static inline IRAM_ATTR void paint_fullheight_4x3()
 {
   const int panelW = 240;

--- a/src/ngp/ngc_display.cpp
+++ b/src/ngp/ngc_display.cpp
@@ -18,6 +18,9 @@ static bool s_lut_ready = false;
 // Entrelacement odd/even
 bool s_interlace_parity = false;
 
+// Color conversion LUT
+extern uint16_t* totalpalette;
+
 static uint16_t* s_linebuf_panel = nullptr;
 static uint16_t* s_lut_x_full    = nullptr;
 static uint16_t* s_lut_y_full    = nullptr;
@@ -133,10 +136,21 @@ static inline void paint_fullscreen_stretch()
     const uint8_t*  base    = (const uint8_t*)srcLine;                 // base 8-bit
     const uint16_t* lutx    = s_lut_x_full;                            // offsets
     uint16_t*       dst     = s_linebuf_panel;
-
     // Unrolled loop for speed
     int x = 0;
     for (; x <= panelW - 8; x += 8) {
+  #ifdef  NGP_USE_THREADED_COLORMAPPING
+        // Use the totalpalette LUT for color conversion
+        dst[x+0] = totalpalette[*(const uint16_t*)(base + lutx[x+0])];
+        dst[x+1] = totalpalette[*(const uint16_t*)(base + lutx[x+1])];
+        dst[x+2] = totalpalette[*(const uint16_t*)(base + lutx[x+2])];
+        dst[x+3] = totalpalette[*(const uint16_t*)(base + lutx[x+3])];
+        dst[x+4] = totalpalette[*(const uint16_t*)(base + lutx[x+4])];
+        dst[x+5] = totalpalette[*(const uint16_t*)(base + lutx[x+5])];
+        dst[x+6] = totalpalette[*(const uint16_t*)(base + lutx[x+6])];
+        dst[x+7] = totalpalette[*(const uint16_t*)(base + lutx[x+7])];
+  #else
+      // Color conversion was already performed
       dst[x+0] = *(const uint16_t*)(base + lutx[x+0]);
       dst[x+1] = *(const uint16_t*)(base + lutx[x+1]);
       dst[x+2] = *(const uint16_t*)(base + lutx[x+2]);
@@ -145,9 +159,16 @@ static inline void paint_fullscreen_stretch()
       dst[x+5] = *(const uint16_t*)(base + lutx[x+5]);
       dst[x+6] = *(const uint16_t*)(base + lutx[x+6]);
       dst[x+7] = *(const uint16_t*)(base + lutx[x+7]);
+#endif
     }
     for (; x < panelW; ++x) {
+#ifdef NGP_USE_THREADED_COLORMAPPING
+      // Use the totalpalette LUT for color conversion
+      dst[x] = totalpalette[*(const uint16_t*)(base + lutx[x])];
+#else
+      // Color conversion was already performed
       dst[x] = *(const uint16_t*)(base + lutx[x]);
+#endif
     }
 
     M5.Display.setAddrWindow(0, y, panelW, 1);
@@ -157,30 +178,66 @@ static inline void paint_fullscreen_stretch()
   M5.Display.endWrite();
 }
 
+  // To do: This function does not appear to have been updated in a while:
+  // - forced interlacing needs to be replaced with updated s_interlace_parity usage
+  // - color conversion optimization like in paint_fullscreen_stretch(), using line buffer - currently incorrect colours when NGP_USE_THREADED_COLORMAPPING is defined
 static inline IRAM_ATTR void paint_fullheight_4x3()
 {
   const int panelW = 240;
   const int panelH = 135;
-  const int srcW   = NGPC_W;   // 160
-  const int srcH   = NGPC_H;   // 152
-
   const int outW    = 160;
   const int x_start = (panelW - outW) / 2; // 40
-  const uint32_t stepY  = ((uint32_t)srcH << 16) / (uint32_t)panelH;
-  const int      parity = (int)s_interlace_parity;
-  uint32_t       accY   = (uint32_t)parity * stepY;
-  const uint32_t stepY2 = stepY << 1; // we skip one line
+  const int srcW   = NGPC_W;
 
   M5.Display.startWrite();
-
+  
+  #ifdef NGP_INTERLACED
+  const int parity = (int)s_interlace_parity;
   for (int y = parity; y < panelH; y += 2) {
-    const int srcY = (int)(accY >> 16);
-    accY += stepY2;
-
-    const uint16_t* __restrict srcLine = drawBuffer + (size_t)srcY * srcW;
+  #else
+  for (int y = 0; y < panelH; y += 1) {
+  #endif
+    const uint16_t  srcY    = s_lut_y_full[y];                         // 0..(srcH-1)
+    const uint16_t* srcLine = drawBuffer + (size_t)srcY * srcW;        // source
+    const uint8_t*  base    = (const uint8_t*)srcLine;                 // base 8-bi
+    uint16_t*       dst     = s_linebuf_panel;
+    // Unrolled loop for speed
+    int x = 0;
+    for (; x <= 160 - 8; x += 8) {
+  #ifdef  NGP_USE_THREADED_COLORMAPPING
+        // Use the totalpalette LUT for color conversion
+      dst[x+0] = totalpalette[*(const uint16_t*)(base + ((x+0) << 1))];
+      dst[x+1] = totalpalette[*(const uint16_t*)(base + ((x+1) << 1))];
+      dst[x+2] = totalpalette[*(const uint16_t*)(base + ((x+2) << 1))];
+      dst[x+3] = totalpalette[*(const uint16_t*)(base + ((x+3) << 1))];
+      dst[x+4] = totalpalette[*(const uint16_t*)(base + ((x+4) << 1))];
+      dst[x+5] = totalpalette[*(const uint16_t*)(base + ((x+5) << 1))];
+      dst[x+6] = totalpalette[*(const uint16_t*)(base + ((x+6) << 1))];
+      dst[x+7] = totalpalette[*(const uint16_t*)(base + ((x+7) << 1))];
+  #else
+      // Color conversion was already performed, copy directly from source to line buffer(or use source buffer directly in next version)
+      dst[x+0] = *(const uint16_t*)(base + ((x+0) << 1));
+      dst[x+1] = *(const uint16_t*)(base + ((x+1) << 1));
+      dst[x+2] = *(const uint16_t*)(base + ((x+2) << 1));
+      dst[x+3] = *(const uint16_t*)(base + ((x+3) << 1));
+      dst[x+4] = *(const uint16_t*)(base + ((x+4) << 1));
+      dst[x+5] = *(const uint16_t*)(base + ((x+5) << 1));
+      dst[x+6] = *(const uint16_t*)(base + ((x+6) << 1));
+      dst[x+7] = *(const uint16_t*)(base + ((x+7) << 1));
+#endif
+    }
+    for (; x < 160; ++x) {
+#ifdef NGP_USE_THREADED_COLORMAPPING
+      // Use the totalpalette LUT for color conversion
+      dst[x] = totalpalette[*(const uint16_t*)(base + (x << 1))];
+#else
+      // Color conversion was already performed
+      dst[x] = *(const uint16_t*)(base + (x << 1));
+#endif
+    }
 
     M5.Display.setAddrWindow(x_start, y, outW, 1);
-    M5.Display.writePixels(srcLine, outW, /*swapBytesAlready=*/true);
+    M5.Display.writePixels(dst, outW, /*swapBytesAlready=*/true);
   }
 
   M5.Display.endWrite();

--- a/src/ngp/race/graphics.h
+++ b/src/ngp/race/graphics.h
@@ -71,7 +71,12 @@ void myGraphicsBlitLine(unsigned char render);
 
 extern uint16_t* totalpalette;
 extern uint16_t *palettes;
+#ifdef  NGP_USE_THREADED_COLORMAPPING
+// disables output color conversion from the emulator itself, providing bgr444 native output
+#define NGPC_TO_SDL16(col) (col & 0x0FFF)
+#else
 #define NGPC_TO_SDL16(col) totalpalette[col & 0x0FFF]
+#endif
 
 #define setColPaletteEntry(addr, data) palettes[(addr)] = NGPC_TO_SDL16(data)
 #define setBWPaletteEntry(addr, data) palettes[(addr)] = NGPC_TO_SDL16(data)

--- a/src/ngp/race/race-memory.c
+++ b/src/ngp/race/race-memory.c
@@ -45,6 +45,9 @@ unsigned char* cpurom  = NULL;
 const unsigned char* mainrom = NULL;    // ROM mapped top XIP
 unsigned char* cpuram = NULL; 
 unsigned char  ldcRegs[64];
+#ifdef USE_PARITY_TABLE
+unsigned char* parityVtable = NULL;            // zero and sign flags table for faster setting
+#endif
 
 static unsigned char* s_cpuram_256 = NULL;
 
@@ -431,11 +434,18 @@ void ngp_mem_init(void)
 		cz80_bind_memory();
     }
 
-
     if (!cpurom) {
         cpurom = (unsigned char*)malloc(0x10000);
         if (!cpurom) for(;;){}
     }
+
+#ifdef USE_PARITY_TABLE
+    if (!parityVtable) {
+        parityVtable = (unsigned char*)malloc(256);
+        if (!parityVtable) for(;;){}
+    }
+#endif
+
     cpuram = &mainram[0];
 	memset(mainram,0,sizeof(mainram));
     switch(m_emuInfo.machine) {

--- a/src/ngp/race/race-memory.c
+++ b/src/ngp/race/race-memory.c
@@ -45,9 +45,6 @@ unsigned char* cpurom  = NULL;
 const unsigned char* mainrom = NULL;    // ROM mapped top XIP
 unsigned char* cpuram = NULL; 
 unsigned char  ldcRegs[64];
-#ifdef USE_PARITY_TABLE
-unsigned char* parityVtable = NULL;            // zero and sign flags table for faster setting
-#endif
 
 static unsigned char* s_cpuram_256 = NULL;
 
@@ -434,18 +431,11 @@ void ngp_mem_init(void)
 		cz80_bind_memory();
     }
 
+
     if (!cpurom) {
         cpurom = (unsigned char*)malloc(0x10000);
         if (!cpurom) for(;;){}
     }
-
-#ifdef USE_PARITY_TABLE
-    if (!parityVtable) {
-        parityVtable = (unsigned char*)malloc(256);
-        if (!parityVtable) for(;;){}
-    }
-#endif
-
     cpuram = &mainram[0];
 	memset(mainram,0,sizeof(mainram));
     switch(m_emuInfo.machine) {

--- a/src/ngp/race/tlcs900h.c
+++ b/src/ngp/race/tlcs900h.c
@@ -107,7 +107,7 @@ extern uint8_t* s_lut_y_render;
 
 //#define USE_PARITY_TABLE  //this is currently broken!
 #ifdef USE_PARITY_TABLE
-unsigned char parityVtable[256];            // zero and sign flags table for faster setting
+extern unsigned char* parityVtable;            // zero and sign flags table for faster setting
 #endif
 
 // declare all registers

--- a/src/ngp/race/tlcs900h.c
+++ b/src/ngp/race/tlcs900h.c
@@ -107,7 +107,7 @@ extern uint8_t* s_lut_y_render;
 
 //#define USE_PARITY_TABLE  //this is currently broken!
 #ifdef USE_PARITY_TABLE
-extern unsigned char* parityVtable;            // zero and sign flags table for faster setting
+unsigned char parityVtable[256];            // zero and sign flags table for faster setting
 #endif
 
 // declare all registers
@@ -8321,10 +8321,14 @@ static int tlcs_step(void)
 
 #ifdef FRAMESKIP
 static int s_framesToSkip = 0;  // refreshes every frame
-void tlcs_execute(int cycles, int skipframe )
-#else
-void tlcs_execute(int cycles)
+
+void tlcs_queueFrameSkip(int framesToSkip)
+{
+    s_framesToSkip = framesToSkip;
+}
 #endif
+
+void tlcs_execute(int cycles)
 {
     int elapsed;
     int hCounter = ngOverflow;
@@ -8418,7 +8422,6 @@ void tlcs_execute(int cycles)
 #ifdef NGP_HW_INTERLACED
                     s_interlace_parity = s_framePatternIdx; // <-- set parity for draw, if 152 lines than the parity the same as the last line
 #endif
-                    s_framesToSkip = skipframe;  // set up next skip cycle
                 }
 #else
 #ifdef NGP_HW_INTERLACED

--- a/src/ngp/race/tlcs900h.h
+++ b/src/ngp/race/tlcs900h.h
@@ -61,10 +61,9 @@ void tlcs_init(void);
 void tlcs_reinit(void);
 /* execute interrupt */
 void tlcs_interrupt_wrapper(int irq);
-#ifdef FRAMESKIP
-void tlcs_execute(int cycles, int skipFrames); /* skipFrames=how many frames to skip for each frame rendered */
-#else
 void tlcs_execute(int cycles);
+#ifdef FRAMESKIP
+void tlcs_queueFrameSkip(int framesToSkip);
 #endif
 
 #ifdef __cplusplus

--- a/src/ngp/run_ngp.cpp
+++ b/src/ngp/run_ngp.cpp
@@ -11,6 +11,8 @@
 #include "ngc_input.h"
 #include "ngc_display.h"
 #include "ngc_scheduler.h"
+#include "esp_timer.h" // used for get_time()
+#include "esp_rom_sys.h" // used for esp_rom_delay_us(us)
 // #include "ngc_bios.h"
 
 #define NGP_LANG_EN 1
@@ -123,6 +125,14 @@ static void map_vdp_tables_full()
   rasterY = scanlineY;
 }
 
+static inline void sleep_until_us(int64_t deadline)
+{
+    int64_t now = esp_timer_get_time();
+    if (deadline > now) {
+        esp_rom_delay_us((uint32_t)(deadline - now));
+    }
+}
+
 void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 {
   // Load ROM
@@ -192,16 +202,18 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
   printf("[NGPC_RUN] starting core loop\n");
 
   #ifdef FRAMESKIP
-      const int skipFrames = 1;
+      unsigned int frame_skipped = 0;
   #endif
 
+  unsigned long now = esp_timer_get_time();
   unsigned long status_last = millis();
   unsigned long frames = 0;
   unsigned long frame_time_total = 0;
   unsigned long frame_time_min = ULONG_MAX;
   unsigned long frame_time_max = 0;
   const uint32_t TARGET_US = 16667; // 60 Hz
-  const uint32_t CPU_CLOCK_HZ = 5700000; // 6 MHz downclocked by 5% (smooth perfs)
+  const uint32_t CPU_CLOCK_HZ = 6000000; // 6 MHz downclocked by 5% (smooth perfs)
+  unsigned long next_deadline = now + TARGET_US;
   
   // Kludges ROM
   switch (tlcsMemReadW(0x00200020)) {
@@ -214,34 +226,59 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 
   while (m_bIsActive)
   {
-      uint32_t t0 = micros();  
+      unsigned long t0 = esp_timer_get_time();
+      unsigned long t0ms = micros();  
 
       // Execute one frame
-      #ifdef FRAMESKIP
-              tlcs_execute((CPU_CLOCK_HZ) / 60, skipFrames);
-      #else
-              tlcs_execute((CPU_CLOCK_HZ) / 60);
-      #endif
+      tlcs_execute((CPU_CLOCK_HZ) / 60);
 
-      // Pacing 60 Hz
-      uint32_t emuUs = micros() - t0;
+
+      // Log framerate
+      uint32_t emuUs = micros() - t0ms;
       frame_time_total += emuUs;
       if (emuUs < frame_time_min) frame_time_min = emuUs;
       if (emuUs > frame_time_max) frame_time_max = emuUs;
-
-      int32_t remaining = TARGET_US - emuUs;
-      if (remaining > 0) {
-        delayMicroseconds(remaining);
-      }
-      
-      // Log framerate
       frames++;
+
+      // Pacing 60 Hz
+      now = esp_timer_get_time();
+      // If we're early, wait 
+      if (now < next_deadline) {
+          sleep_until_us(next_deadline);
+          now = next_deadline;
+      }
+
+      if (now > next_deadline + TARGET_US) 
+      {
+        next_deadline = now;
+        #ifdef FRAMESKIP
+        // Queue a skip frame to catch up
+        tlcs_queueFrameSkip(1);
+        frame_skipped++;
+        frames++;
+        #endif
+      }
+      next_deadline += TARGET_US;
+      
+
       if (millis() - status_last >= 2000)
       {
           size_t heap_free = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
           float avg_ms = frame_time_total / (float)frames / 1000.0f;
           float min_ms = frame_time_min / 1000.0f;
           float max_ms = frame_time_max / 1000.0f;
+          #ifdef FRAMESKIP
+          printf("[NGP_RUN] %lu[%d] frames / 2s (~%lu FPS) | HEAP: %u bytes (%.1f KB) | AVG %.2fms | MIN %.2fms | MAX %.2fms\n",
+          frames,
+          frame_skipped,
+          frames / 2,
+          (unsigned int)heap_free,
+          heap_free / 1024.0f,
+          avg_ms,
+          min_ms,
+          max_ms);
+          frame_skipped=0;
+          #else
           printf("[NGP_RUN] %lu frames / 2s (~%lu FPS) | HEAP: %u bytes (%.1f KB) | AVG %.2fms | MIN %.2fms | MAX %.2fms\n",
           frames,
           frames / 2,
@@ -250,6 +287,7 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
           avg_ms,
           min_ms,
           max_ms);
+          #endif
           frame_time_total = 0;
           frame_time_min = ULONG_MAX;
           frame_time_max = 0;

--- a/src/ngp/run_ngp.cpp
+++ b/src/ngp/run_ngp.cpp
@@ -203,7 +203,7 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
   const uint32_t TARGET_US = 16667; // 60 Hz
   const uint32_t CPU_CLOCK_HZ = 5700000; // 6 MHz downclocked by 5% (smooth perfs)
   unsigned long next_deadline = now + TARGET_US;
-  uint8_t MAX_LAG_FRAMES = 2; // max number of frames we can lag, prevents overruns after a period of running slow
+  float MAX_LAG_FRAMES = 1.1; // max number of frames we can lag, prevents overruns after a period of running slow
   uint32_t MAX_LAG_US = (MAX_LAG_FRAMES * TARGET_US);
 #ifdef FRAMESKIP
   unsigned int frame_skipped = 0;
@@ -241,8 +241,7 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 
       // We fell way behind — drop backlog
       if (now > next_deadline + MAX_LAG_US)
-        next_deadline -= TARGET_US;
-        //next_deadline = now - TARGET_US;
+        next_deadline = now - MAX_LAG_US; // clamp to ceiling.
 
       // If we're early, wait 
       if (now < next_deadline) {

--- a/src/ngp/run_ngp.cpp
+++ b/src/ngp/run_ngp.cpp
@@ -12,6 +12,7 @@
 #include "ngc_display.h"
 #include "ngc_scheduler.h"
 #include "esp_timer.h" // used for get_time()
+#include "../../share/utils.h"
 #include "esp_rom_sys.h" // used for esp_rom_delay_us(us)
 // #include "ngc_bios.h"
 
@@ -125,14 +126,6 @@ static void map_vdp_tables_full()
   rasterY = scanlineY;
 }
 
-static inline void sleep_until_us(int64_t deadline)
-{
-    int64_t now = esp_timer_get_time();
-    if (deadline > now) {
-        esp_rom_delay_us((uint32_t)(deadline - now));
-    }
-}
-
 void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 {
   // Load ROM
@@ -201,10 +194,6 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 
   printf("[NGPC_RUN] starting core loop\n");
 
-  #ifdef FRAMESKIP
-      unsigned int frame_skipped = 0;
-  #endif
-
   unsigned long now = esp_timer_get_time();
   unsigned long status_last = millis();
   unsigned long frames = 0;
@@ -212,9 +201,16 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
   unsigned long frame_time_min = ULONG_MAX;
   unsigned long frame_time_max = 0;
   const uint32_t TARGET_US = 16667; // 60 Hz
-  const uint32_t CPU_CLOCK_HZ = 6000000; // 6 MHz 
+  const uint32_t CPU_CLOCK_HZ = 5700000; // 6 MHz downclocked by 5% (smooth perfs)
   unsigned long next_deadline = now + TARGET_US;
-  
+  uint8_t MAX_LAG_FRAMES = 2; // max number of frames we can lag, prevents overruns after a period of running slow
+  uint32_t MAX_LAG_US = (MAX_LAG_FRAMES * TARGET_US);
+#ifdef FRAMESKIP
+  unsigned int frame_skipped = 0;
+  unsigned int frames_to_render = 0; // how many frames to render before skipping is an possibility  
+#endif
+
+
   // Kludges ROM
   switch (tlcsMemReadW(0x00200020)) {
     case 0x0059:   // Sonic
@@ -242,22 +238,34 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
 
       // Pacing 60 Hz
       now = esp_timer_get_time();
+
+      // We fell way behind — drop backlog
+      if (now > next_deadline + MAX_LAG_US)
+        next_deadline -= TARGET_US;
+        //next_deadline = now - TARGET_US;
+
       // If we're early, wait 
       if (now < next_deadline) {
-          sleep_until_us(next_deadline);
+          share::sleep_until_us(next_deadline-200); // throw away a little time to use for the next frame, 200us*60 = 12ms, not even one frame extra a second
           now = next_deadline;
       }
-
-      if (now > next_deadline + TARGET_US) 
+    
+      #ifdef FRAMESKIP
+      if ((now >= (next_deadline + TARGET_US)) && (frames_to_render <= 0))
       {
-        next_deadline = now;
-        #ifdef FRAMESKIP
+        frames_to_render = 4; // This forces a skip frame not to be conisdered again for 5 frames, the first is decremented during this triggered skip frame
         // Queue a skip frame to catch up
         tlcs_queueFrameSkip(1);
         frame_skipped++;
-        frames++;
-        #endif
+        
       }
+      else
+      { // Only advance time if we are not skipping a frame
+        // next_deadline += TARGET_US;
+        if (frames_to_render > 0)
+          frames_to_render--;
+      }
+      #endif
       next_deadline += TARGET_US;
       
 

--- a/src/ngp/run_ngp.cpp
+++ b/src/ngp/run_ngp.cpp
@@ -212,7 +212,7 @@ void run_ngp(const uint8_t* rom_base, size_t rom_size, int machine)
   unsigned long frame_time_min = ULONG_MAX;
   unsigned long frame_time_max = 0;
   const uint32_t TARGET_US = 16667; // 60 Hz
-  const uint32_t CPU_CLOCK_HZ = 6000000; // 6 MHz downclocked by 5% (smooth perfs)
+  const uint32_t CPU_CLOCK_HZ = 6000000; // 6 MHz 
   unsigned long next_deadline = now + TARGET_US;
   
   // Kludges ROM


### PR DESCRIPTION
Both Metal Slug 1 and Baseball average frame rate 58-60fps in standard benchmark runs. Never breaks 60, frame skipping is not aggressive with a threshold that results in only the required number of skipped frames being triggered.

* Changed frame skip interface (new queue function, removed old atypical logic)
* Switched to microsecond timing functions(ms preserved for old frame time logic)
* Switched to projected deadline pacing
* Added threshold based auto frameskip
* Added alternate stats for when frameskip is enabled
* Threw out changes to enable the parity table, suggest removing this feature entirely to avoid confusion. Performance is already very strong without a broken hack, and I can probably get another micro-optimization or two out of it if required.
* Fixed bug where skipped frames were counted twice
* Switched to share::sleep_until_us()
* Added forced rendered frame between skipped frames(forces 3/75% to render)
* Subtracted 200us from any potential delay operation(200us*60=12ms/less than one frame) to give extra time for emulation
* Seems to have increased frame rate overall by about 1fps in baseball, megaman shows some loose timing with 62fps highs but overall slightly faster as well.
* Accounting adjusted for better pacing with the skip frames disabled because:
Some quick estimates show that skipped frames can only make up a small amount of time, 2-5ms which at a max of 15(25%) frames means 30-75ms savings, 2-3fps gained for 15 skipped frames a second. This may not be a worthwhile trade off.