### PR TITLE
MSX: include EMULib Sound header explicitly to fix missing Drum/DRM_C…

### DIFF
--- a/src/msx/fMSX/MSX.c
+++ b/src/msx/fMSX/MSX.c
@@ -15,7 +15,7 @@
 /*************************************************************/
 
 #include "MSX.h"
-#include "Sound.h"
+#include "../EMULib/Sound.h"
 #ifndef NO_FLOPPY
 #include "Floppy.h"
 #endif


### PR DESCRIPTION
…LICK declarations

Summary

Fixes the MSX build by including the EMULib Sound.h header explicitly from MSX.c.

Details

MSX.c uses symbols declared by EMULib's sound API, including Drum(), DRM_CLICK, InitMIDI(), TrashMIDI(), and MIDITicks().

The original code used #include "Sound.h". That can work in the original upstream build environment if src/msx/EMULib is present in the compiler include paths with the expected priority.

In some PlatformIO environments, however, the include path order is different and more crowded because it also includes project sources, libraries, .pio/libdeps, and the Arduino framework.

Using the explicit relative include #include "../EMULib/Sound.h" makes the dependency stable and independent from the build environment include path ordering.

This ensures the MSX core consistently sees the correct EMULib sound declarations and the NO_MIDI fallback macros during compilation.