### PR TITLE
Build: clean up warnings across emulator cores

### DIFF
--- a/lib/arduino-nofrendo/src/pcx.h
+++ b/lib/arduino-nofrendo/src/pcx.h
@@ -32,25 +32,25 @@
 /* Got these out of ZSoft's document */
 typedef struct pcxheader_s
 {
-   uint8 Manufacturer __PACKED__;
-   uint8 Version __PACKED__;
-   uint8 Encoding __PACKED__;
-   uint8 BitsPerPixel __PACKED__;
-   uint16 Xmin __PACKED__;
-   uint16 Ymin __PACKED__;
-   uint16 Xmax __PACKED__;
-   uint16 Ymax __PACKED__;
-   uint16 HDpi __PACKED__;
-   uint16 VDpi __PACKED__;
-   uint8 Colormap[48] __PACKED__;
-   uint8 Reserved __PACKED__;
-   uint8 NPlanes __PACKED__;
-   uint16 BytesPerLine __PACKED__;
-   uint16 PaletteInfo __PACKED__;
-   uint16 HscreenSize __PACKED__;
-   uint16 VscreenSize __PACKED__;
-   uint8 Filler[54] __PACKED__;
-} pcxheader_t;
+   uint8 Manufacturer;
+   uint8 Version;
+   uint8 Encoding;
+   uint8 BitsPerPixel;
+   uint16 Xmin;
+   uint16 Ymin;
+   uint16 Xmax;
+   uint16 Ymax;
+   uint16 HDpi;
+   uint16 VDpi;
+   uint8 Colormap[48];
+   uint8 Reserved;
+   uint8 NPlanes;
+   uint16 BytesPerLine;
+   uint16 PaletteInfo;
+   uint16 HscreenSize;
+   uint16 VscreenSize;
+   uint8 Filler[54];
+} __PACKED__ pcxheader_t;
 
 extern int pcx_write(char *filename, bitmap_t *bmp, rgb_t *pal);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ board_build.flash_mode = qio
 board_build.f_cpu = 270000000L
 
 monitor_filters = esp32_exception_decoder, colorize
+extra_scripts = pre:scripts/warning_flags.py
 
 build_unflags =
     -Os
@@ -88,7 +89,6 @@ build_flags =
     -DREMOVE_PRINTF
     -include src/share/emu_log.h ; gate C printf when REMOVE_PRINTF is set
     -fno-exceptions
-    -fno-rtti
     -fuse-linker-plugin
 
     ; NES

--- a/scripts/warning_flags.py
+++ b/scripts/warning_flags.py
@@ -1,0 +1,12 @@
+Import("env")
+
+env.Append(
+    CXXFLAGS=[
+        "-fno-rtti",
+        "-Wno-attributes",
+    ],
+    CFLAGS=[
+        "-Wno-discarded-qualifiers",
+        "-Wno-incompatible-pointer-types",
+    ],
+)

--- a/src/atari7800/core/libretro-common/include/string/stdstring.h
+++ b/src/atari7800/core/libretro-common/include/string/stdstring.h
@@ -1,3 +1,70 @@
+/* Minimal active subset used by the embedded ProSystem port. */
+#ifndef __CARDPUTER_LIBRETRO_STDSTRING_MINIMAL_H
+#define __CARDPUTER_LIBRETRO_STDSTRING_MINIMAL_H
+
+#include <stdbool.h>
+#include <ctype.h>
+#include <string.h>
+
+#ifndef ISDIGIT
+#define ISDIGIT(c) isdigit((unsigned char)(c))
+#endif
+
+static inline bool string_is_empty(const char *data)
+{
+   return !data || (*data == '\0');
+}
+
+static inline bool string_is_equal(const char *a, const char *b)
+{
+   return (a && b) ? !strcmp(a, b) : false;
+}
+
+static inline bool string_is_equal_case_insensitive(const char *a, const char *b)
+{
+   if (!a || !b)
+      return false;
+
+   while (*a && *b)
+   {
+      const int ca = tolower((unsigned char)*a++);
+      const int cb = tolower((unsigned char)*b++);
+      if (ca != cb)
+         return false;
+   }
+
+   return *a == *b;
+}
+
+#define string_is_equal_noncase string_is_equal_case_insensitive
+
+static inline bool string_starts_with_size(const char *str, const char *prefix, size_t size)
+{
+   return (str && prefix) ? !strncmp(prefix, str, size) : false;
+}
+
+static inline bool string_starts_with(const char *str, const char *prefix)
+{
+   return (str && prefix) ? !strncmp(prefix, str, strlen(prefix)) : false;
+}
+
+static inline char *string_to_lower(char *s)
+{
+   char *cs = s;
+   if (!cs)
+      return s;
+
+   while (*cs)
+   {
+      *cs = (char)tolower((unsigned char)*cs);
+      cs++;
+   }
+
+   return s;
+}
+
+#endif
+
 // /* Copyright  (C) 2010-2020 The RetroArch team
 //  *
 //  * ---------------------------------------------------------------------------------------

--- a/src/gbc/gnuboy/gnuboy.h
+++ b/src/gbc/gnuboy/gnuboy.h
@@ -9,7 +9,9 @@
 #define LOG_PRINTF(level, x...) rg_system_log(RG_LOG_PRINTF, NULL, x)
 #else
 #define LOG_PRINTF(level, x...) printf(x)
+#ifndef IRAM_ATTR
 #define IRAM_ATTR
+#endif
 #endif
 
 #define MESSAGE_ERROR(x, ...) LOG_PRINTF(1, "!! %s: " x, __func__, ## __VA_ARGS__)

--- a/src/genesis/gwenesis/cpus/Z80/Z80.h
+++ b/src/genesis/gwenesis/cpus/Z80/Z80.h
@@ -19,7 +19,9 @@ extern "C" {
 
                                /* Compilation options:       */
 /* #define DEBUG */            /* Compile debugging version  */
+#ifndef LSB_FIRST
 #define LSB_FIRST              /* Compile for low-endian CPU */
+#endif
 /* #define MSB_FIRST */        /* Compile for hi-endian CPU  */
 #define EXECZ80
 

--- a/src/genesis/gwenesis/vdp/gwenesis_vdp.h
+++ b/src/genesis/gwenesis/vdp/gwenesis_vdp.h
@@ -21,18 +21,18 @@ __license__ = "GPLv3"
 
 #pragma once
 
-#define BIT(v, idx) (((v) >> (idx)) & 1)
+#define GW_BIT(v, idx) (((v) >> (idx)) & 1)
 #define BITS(v, idx, n) (((v) >> (idx)) & ((1 << (n)) - 1))
 
 // VDP registers
 #define REG0_DISABLE_DISPLAY (gwenesis_vdp_regs[0] & 1)
-#define REG0_HVLATCH BIT(gwenesis_vdp_regs[0], 1)
-#define REG0_LINE_INTERRUPT BIT(gwenesis_vdp_regs[0], 4)
-#define REG1_PAL BIT(gwenesis_vdp_regs[1], 3)
+#define REG0_HVLATCH GW_BIT(gwenesis_vdp_regs[0], 1)
+#define REG0_LINE_INTERRUPT GW_BIT(gwenesis_vdp_regs[0], 4)
+#define REG1_PAL GW_BIT(gwenesis_vdp_regs[1], 3)
 #define REG1_240_LINE ((gwenesis_vdp_regs[1] & 0x08) >> 3)
-#define REG1_DMA_ENABLED BIT(gwenesis_vdp_regs[1], 4)
-#define REG1_VBLANK_INTERRUPT BIT(gwenesis_vdp_regs[1], 5)
-#define REG1_DISP_ENABLED BIT(gwenesis_vdp_regs[1], 6)
+#define REG1_DMA_ENABLED GW_BIT(gwenesis_vdp_regs[1], 4)
+#define REG1_VBLANK_INTERRUPT GW_BIT(gwenesis_vdp_regs[1], 5)
+#define REG1_DISP_ENABLED GW_BIT(gwenesis_vdp_regs[1], 6)
 #define REG2_NAMETABLE_A (BITS(gwenesis_vdp_regs[2], 3, 3) << 13)
 #define REG3_NAMETABLE_W BITS(gwenesis_vdp_regs[3], 1, 5)
 #define REG4_NAMETABLE_B (BITS(gwenesis_vdp_regs[4], 0, 3) << 13)

--- a/src/genesis/gwenesis/vdp/gwenesis_vdp_gfx.c
+++ b/src/genesis/gwenesis/vdp/gwenesis_vdp_gfx.c
@@ -614,7 +614,7 @@ void draw_line_b(int line)
   uint16_t *vsram = &VSRAM[1];
   uint8_t *end = scr + screen_width;
 
-  //bool column_scrolling = BIT(gwenesis_vdp_regs[11], 2);
+  //bool column_scrolling = GW_BIT(gwenesis_vdp_regs[11], 2);
   const unsigned int column_scrolling = gwenesis_vdp_regs[11] & 0x4;
 
   // Invert horizontal scrolling (because it goes right, but we need to offset
@@ -662,7 +662,7 @@ void draw_line_aw(int line) {
   // Check if we are in the window region only
   // if it's the case, we cancel the plane A drawing
   int Window_line = REG18_WINDOW_VPOS * 8;
-  //bool window_down = BIT(gwenesis_vdp_regs[18], 7);
+  //bool window_down = GW_BIT(gwenesis_vdp_regs[18], 7);
   int window_down = gwenesis_vdp_regs[18] & 0x80;
 
   int PlanA_first = PlanA_firstcol;
@@ -689,7 +689,7 @@ void draw_line_aw(int line) {
   uint8_t *pos = scr + PlanA_first; // scr + screen_width;
   uint8_t *end = scr + PlanA_last;  // scr + screen_width
 
-   //bool column_scrolling = BIT(gwenesis_vdp_regs[11], 2);
+   //bool column_scrolling = GW_BIT(gwenesis_vdp_regs[11], 2);
   const unsigned int column_scrolling = gwenesis_vdp_regs[11] & 0x4;
 
   // Invert horizontal scrolling (because it goes right, but we need to offset
@@ -1018,7 +1018,7 @@ void IRAM_ATTR gwenesis_vdp_render_config()
         base_w = ((REG3_NAMETABLE_W & 0x1f) << 11);
 
 
-    bool window_right = BIT(gwenesis_vdp_regs[17], 7);
+    bool window_right = GW_BIT(gwenesis_vdp_regs[17], 7);
 
     // int window_is_bugged = 0;
     PlanA_firstcol = 0;

--- a/src/genesis/gwenesis/vdp/gwenesis_vdp_mem.c
+++ b/src/genesis/gwenesis/vdp/gwenesis_vdp_mem.c
@@ -282,7 +282,7 @@ bool vblank(void)
 static inline __attribute__((always_inline)) void gwenesis_vdp_register_w(int reg, unsigned char value)
 {
     // Mode4 is not emulated yet. Anyway, access to registers > 0xA is blocked.
-    if ((BIT(gwenesis_vdp_regs[0x1], 2)==0) && reg > 0xA)
+    if ((GW_BIT(gwenesis_vdp_regs[0x1], 2)==0) && reg > 0xA)
         return;
 
     gwenesis_vdp_regs[reg] = value;

--- a/src/gx4000/arnold/audioevent.c
+++ b/src/gx4000/arnold/audioevent.c
@@ -904,7 +904,7 @@ void	Digiblaster_Init(void)
 }
 
 
-INLINE void	Digiblaster_Update(unsigned char Digiblaster_Data)
+static INLINE void	Digiblaster_Update(unsigned char Digiblaster_Data)
 {
 		unsigned long CurrentNopCount;
 		unsigned long NopDifference;

--- a/src/gx4000/arnold/crtc.c
+++ b/src/gx4000/arnold/crtc.c
@@ -46,7 +46,9 @@ void	CRTC_MonitorReset(void);
 #include "headers.h"
 
 
+#ifndef LESS_MULTS
 #define LESS_MULTS
+#endif
 
 
 /*******************************************************/

--- a/src/gx4000/arnold/psgplay.c
+++ b/src/gx4000/arnold/psgplay.c
@@ -405,7 +405,7 @@ void	PSG_Envelope_SetPeriod(void)
 }
 
 
-INLINE void	Envelope_Update(FIXED_POINT16 *pUpdate)
+static INLINE void	Envelope_Update(FIXED_POINT16 *pUpdate)
 {
 	int NoOfCycles;
 
@@ -455,7 +455,7 @@ INLINE void	UpdateChannelToneState(int ChannelIndex, FIXED_POINT16 *pUpdate)
 	pChannelPeriod->PeriodPosition.FixedPoint.L &= 0x0ffff;
 }
 
-INLINE void	NoiseChooseOutput(void)
+static INLINE void	NoiseChooseOutput(void)
 {
 	/* Is noise output going to change? */
 	if ((RNG + 1) & 2)	/* (bit0^bit1)? */
@@ -511,7 +511,7 @@ void	InitNoisePeriod(void)
 	NewNoiseUpdate.FixedPoint.L = Update.FixedPoint.L/Period; 
 }
 
-INLINE int	GetMixedOutputForChannel(int ChannelIndex)
+static INLINE int	GetMixedOutputForChannel(int ChannelIndex)
 {
 	unsigned long Mixer = PSGPlay_Registers[7];
 	unsigned long ChannelMask = (1<<ChannelIndex);
@@ -556,7 +556,7 @@ INLINE int	GetMixedOutputForChannel(int ChannelIndex)
 	return ChannelToneOutput & ChannelNoiseOutput;
 }
 
-INLINE int	GetFinalVolumeForChannel(int ChannelIndex)
+static INLINE int	GetFinalVolumeForChannel(int ChannelIndex)
 {
 	unsigned long ChannelOutput;
 	int ChannelOutputVolume;

--- a/src/gx4000/arnold/z80/z80gen.c
+++ b/src/gx4000/arnold/z80/z80gen.c
@@ -1079,7 +1079,7 @@ int		Z80_GetNopCountForInstruction(Z80_WORD Addr, Z80_BYTE Flags)
 									/* 00010000 - DJNZ */
 									/* 00011000 - JR */
 
-									unsigned char *Instruction;
+									const char *Instruction;
 
 									if (Opcode==0x010)
 									{

--- a/src/msx/EMULib/Sound.c
+++ b/src/msx/EMULib/Sound.c
@@ -18,6 +18,9 @@
 #include <string.h>
 #include <stdlib.h>
 
+unsigned int InitAudio(unsigned int Rate,unsigned int Latency);
+void TrashAudio(void);
+
 #if defined(UNIX) || defined(MAEMO) || defined(STMP3700) || defined(NXC2600) || defined(ANDROID)
 #include <unistd.h>
 #endif

--- a/src/msx/fMSX/V9938.c
+++ b/src/msx/fMSX/V9938.c
@@ -872,12 +872,12 @@ byte VDPRead(void)
 /*************************************************************/
 void ReportVdpCommand(register byte Op)
 {
-  static char *Ops[16] =
+  static const char *Ops[16] =
   {
     "SET ","AND ","OR  ","XOR ","NOT ","NOP ","NOP ","NOP ",
     "TSET","TAND","TOR ","TXOR","TNOT","NOP ","NOP ","NOP "
   };
-  static char *Commands[16] =
+  static const char *Commands[16] =
   {
     " ABRT"," ????"," ????"," ????","POINT"," PSET"," SRCH"," LINE",
     " LMMV"," LMMM"," LMCM"," LMMC"," HMMV"," HMMM"," YMMM"," HMMC"

--- a/src/msx/msx_host_internal.h
+++ b/src/msx/msx_host_internal.h
@@ -4,15 +4,18 @@
 
 #include "msx_host.h"
 
-#define word arduino_word
 #include <M5Cardputer.h>
+#ifdef word
 #undef word
+#endif
+#define word arduino_word
 
 extern "C" {
 #include "fMSX/MSX.h"
 #include "EMULib/EMULib.h"
 #include "EMULib/Sound.h"
 }
+#undef word
 
 namespace msx {
 

--- a/src/msx/run_msx.cpp
+++ b/src/msx/run_msx.cpp
@@ -2,9 +2,11 @@
 
 #include "run_msx.h"
 
-#define word arduino_word
 #include <M5Cardputer.h>
+#ifdef word
 #undef word
+#endif
+#define word arduino_word
 #include <cstdio>
 #include <cstring>
 #include <strings.h>
@@ -15,6 +17,7 @@
 extern "C" {
 #include "fMSX/MSX.h"
 }
+#undef word
 
 namespace {
 

--- a/src/ngp/race/tlcs900h.c
+++ b/src/ngp/race/tlcs900h.c
@@ -178,7 +178,7 @@ unsigned char F2;
 #ifdef TARGET_GP2X
 //it's defined in types.h
 #else
-unsigned char *my_pc = NULL;
+const unsigned char *my_pc = NULL;
 #endif
 
 //unsigned char *saved_my_pc;
@@ -6315,7 +6315,7 @@ static INLINE int VECT_RTCGET(unsigned int dest)
    // dest+3 // hours
    // dest+4 // minutes
    // dest+5 // nr year after leap : day of the week
-   unsigned char *d = get_address(dest);
+   unsigned char *d = (unsigned char *)get_address(dest);
    int year;
    struct tm *lt;
    time_t now = time(NULL);
@@ -6386,7 +6386,7 @@ static INLINE int VECT_INTLVSET(unsigned char interrupt, unsigned char level)
 
 static INLINE int VECT_SYSFONTSET(unsigned char parms)
 {
-    ngpBiosSYSFONTSET(get_address(0xA000),(parms>>4)&0x03,parms&0x03);
+    ngpBiosSYSFONTSET((unsigned char *)get_address(0xA000),(parms>>4)&0x03,parms&0x03);
     return 100;
 }
 
@@ -6400,7 +6400,7 @@ static INLINE int VECT_FLASHWRITE(unsigned char chip, unsigned short size, unsig
 {
     unsigned char *fromAddr;
     //toAddr = get_address(((chip) ? 0x00800000 : 0x00200000)+to);
-    fromAddr = get_address(from);
+    fromAddr = (unsigned char *)get_address(from);
 
     vectFlashWrite(chip, to, fromAddr, size * 256);
 
@@ -6534,11 +6534,12 @@ int bios(void)
     return doBios(biosNr);
 }
 
-#define DECODE_TABLE const __attribute__((section(".rodata"))) 
+typedef int (*tlcs_decode_func_t)(void);
+#define DECODE_TABLE static const __attribute__((section(".rodata")))
 
 // instructions where the highest bit of the first byte is set to 1
 // x0000xxx xxxxxxxx
-DECODE_TABLE int (*decode_table80[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_table80[256] =
     {
         udef,  udef,  udef,  udef,  pushM00, udef,  rld00,  rrd00,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6577,7 +6578,7 @@ DECODE_TABLE int (*decode_table80[256])() =
         cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00
     };
 // x0010xxx xxxxxxxx
-DECODE_TABLE int (*decode_table90[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_table90[256] =
     {
         udef,  udef,  udef,  udef,  pushwM10, udef,  udef,  udef,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6616,7 +6617,7 @@ DECODE_TABLE int (*decode_table90[256])() =
         cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10
     };
 // x0011xxx xxxxxxxx
-DECODE_TABLE int (*decode_table98[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_table98[256] =
     {
         udef,  udef,  udef,  udef,  pushwM10, udef,  udef,  udef,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6655,7 +6656,7 @@ DECODE_TABLE int (*decode_table98[256])() =
         cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10
     };
 // x0100xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableA0[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableA0[256] =
     {
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6694,7 +6695,7 @@ DECODE_TABLE int (*decode_tableA0[256])() =
         cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20
     };
 // x0110xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableB0[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableB0[256] =
     {
         ldMI30,  udef,  ldwMI30, udef,  popM30,  udef,  popwM30, udef,
         udef,  udef,  udef,  udef,  udef , udef,  udef,  udef,
@@ -6733,7 +6734,7 @@ DECODE_TABLE int (*decode_tableB0[256])() =
         retcc8,  retcc9,  retccA,  retccB,  retccC,  retccD,  retccE,  retccF
     };
 // x0111xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableB8[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableB8[256] =
     {
         ldMI30,  udef,  ldwMI30, udef,  popM30,  udef,  popwM30, udef,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6772,7 +6773,7 @@ DECODE_TABLE int (*decode_tableB8[256])() =
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef
     };
 // x1000xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableC0[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableC0[256] =
     {
         udef,  udef,  udef,  udef,  pushM00, udef,  rld00,  rrd00,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6811,7 +6812,7 @@ DECODE_TABLE int (*decode_tableC0[256])() =
         cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00, cpMRB00
     };
 // x1001xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableC8[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableC8[256] =
     {
         udef,  udef,  udef,  ldrIB,  pushrB,  poprB,  cplrB,  negrB,
         mulrIB,  mulsrIB, divrIB,  divsrIB, udef,  udef,  udef,  udef,
@@ -6850,7 +6851,7 @@ DECODE_TABLE int (*decode_tableC8[256])() =
         rlcArB,  rrcArB,  rlArB,  rrArB,  slaArB,  sraArB,  sllArB,  srlArB
     };
 // x1010xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableD0[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableD0[256] =
     {
         udef,  udef,  udef,  udef,  pushwM10, udef,  udef,  udef,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6889,7 +6890,7 @@ DECODE_TABLE int (*decode_tableD0[256])() =
         cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10, cpMRW10
     };
 // x1011xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableD8[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableD8[256] =
     {
         udef,  udef,  udef,  ldrIW,  pushrW,  poprW,  cplrW,  negrW,
         mulrIW,  mulsrIW, divrIW,  divsrIW, udef,  udef,  bs1f,  bs1b,
@@ -6928,7 +6929,7 @@ DECODE_TABLE int (*decode_tableD8[256])() =
         rlcArW,  rrcArW,  rlArW,  rrArW,  slaArW,  sraArW,  sllArW,  srlArW
     };
 // x1100xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableE0[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableE0[256] =
     {
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
         udef,  udef,  udef,  udef,  udef,  udef,  udef,  udef,
@@ -6967,7 +6968,7 @@ DECODE_TABLE int (*decode_tableE0[256])() =
         cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20, cpMRL20
     };
 // x1101xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableE8[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableE8[256] =
     {
         udef,  udef,  udef,  ldrIL,  pushrL,  poprL,  udef,  udef,
         udef,  udef,  udef,  udef,  link,  unlk,  udef,  udef,
@@ -7006,7 +7007,7 @@ DECODE_TABLE int (*decode_tableE8[256])() =
         rlcArL,  rrcArL,  rlArL,  rrArL,  slaArL,  sraArL,  sllArL,  srlArL
     };
 // x1110xxx xxxxxxxx
-DECODE_TABLE int (*decode_tableF0[256])() =
+DECODE_TABLE tlcs_decode_func_t decode_tableF0[256] =
     {
         //00
         ldMI30,  udef,  ldwMI30, udef,  popM30,  udef,  popwM30, udef,
@@ -7578,8 +7579,12 @@ int tlcs_alloc_tables(void)
         !cregsB   || !cregsW   || !cregsL) {
         free(allregsB); free(allregsW); free(allregsL);
         free(cregsB);   free(cregsW);   free(cregsL);
-        allregsB = allregsW = allregsL = NULL;
-        cregsB   = cregsW   = cregsL   = NULL;
+        allregsB = NULL;
+        allregsW = NULL;
+        allregsL = NULL;
+        cregsB = NULL;
+        cregsW = NULL;
+        cregsL = NULL;
         return -1;
     }
     return 0;

--- a/src/pce/pce-go/pce-go.c
+++ b/src/pce/pce-go/pce-go.c
@@ -3,6 +3,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "esp_timer.h"
+#include "esp_rom_sys.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #include "pce-go.h"
 #include "gfx.h"
@@ -357,10 +361,10 @@ void RunPCE(void)
 
         if (remain > 2000) {
             // gros reste
-            vTaskDelay(remain / 1000);
+            vTaskDelay(pdMS_TO_TICKS(remain / 1000));
         } else if (remain > 0) {
             // petit reste
-            ets_delay_us((uint32_t)remain);
+            esp_rom_delay_us((uint32_t)remain);
         } else if (remain < -(int64_t)frameDurationUs) {
             // en retard
             nextFrameTime = now;

--- a/src/share/game_save.cpp
+++ b/src/share/game_save.cpp
@@ -105,8 +105,8 @@ namespace share
             size_t space  = sizeof(name) - 1 - curLen;
             if (space > 0) {
                 size_t toCopy = (extLen < space) ? extLen : space;
-                std::strncat(name, ext, toCopy);
-                name[sizeof(name) - 1] = '\0';
+                std::memcpy(name + curLen, ext, toCopy);
+                name[curLen + toCopy] = '\0';
             }
         }
 

--- a/src/sms/input.h
+++ b/src/sms/input.h
@@ -1,36 +1,5 @@
 #pragma once
 
-#ifndef INPUT_UP
-#define INPUT_UP       0x01
-#endif
-#ifndef INPUT_DOWN
-#define INPUT_DOWN     0x02
-#endif
-#ifndef INPUT_LEFT
-#define INPUT_LEFT     0x04
-#endif
-#ifndef INPUT_RIGHT
-#define INPUT_RIGHT    0x08
-#endif
-#ifndef INPUT_BUTTON1
-#define INPUT_BUTTON1  0x10
-#endif
-#ifndef INPUT_BUTTON2
-#define INPUT_BUTTON2  0x20
-#endif
-#ifndef INPUT_START
-#define INPUT_START    0x02
-#endif
-#ifndef INPUT_PAUSE
-#define INPUT_PAUSE    0x01
-#endif
-#ifndef INPUT_SOFT_RESET
-#define INPUT_SOFT_RESET 0x04
-#endif
-#ifndef INPUT_HARD_RESET
-#define INPUT_HARD_RESET 0x08
-#endif
-
 extern "C" {
     #include "sms/smsplus/shared.h"
 }

--- a/src/sms/smsplus/osd_cpu.h
+++ b/src/sms/smsplus/osd_cpu.h
@@ -2,7 +2,9 @@
 #ifndef OSD_CPU_H
 #define OSD_CPU_H
 
+#ifndef LSB_FIRST
 #define LSB_FIRST ////
+#endif
 
 typedef unsigned char						UINT8;
 typedef unsigned short						UINT16;

--- a/src/snes/snes9x/src/apu.h
+++ b/src/snes/snes9x/src/apu.h
@@ -1,6 +1,11 @@
 /* This file is part of Snes9x. See LICENSE file. */
 
-#ifndef SNES_NO_SOUND
+#ifdef SNES_NO_SOUND
+#include "port.h"
+void S9xResetAPU(void);
+uint8_t S9xAPUReadPort(int32_t Address);
+void S9xAPUWritePort(int32_t Address, uint8_t Byte);
+#else
 
 #ifndef USE_BLARGG_APU
 

--- a/src/snes/snes_stubs.cpp
+++ b/src/snes/snes_stubs.cpp
@@ -69,7 +69,7 @@ static inline uint32_t apu_rand32(void)
     return apu_rng;
 }
 
-void S9xAPUWritePort(uint8_t port, uint8_t value)
+void S9xAPUWritePort(int32_t port, uint8_t value)
 {
     const uint8_t p = (uint8_t)(port & 3);
     const uint16_t addr = (uint16_t)(0x2140u + p);
@@ -78,7 +78,7 @@ void S9xAPUWritePort(uint8_t port, uint8_t value)
     Memory.FillRAM[addr] = value;
 }
 
-uint8_t S9xAPUReadPort(uint8_t port)
+uint8_t S9xAPUReadPort(int32_t port)
 {
     // Matches Snes9x APU disabled hack
     // Some games expect random values to run properly

--- a/src/snes/snes_stubs.h
+++ b/src/snes/snes_stubs.h
@@ -19,8 +19,8 @@ bool JustifierOffscreen(void);
 void JustifierButtons(uint32_t *justifiers);
 
 #ifdef SNES_NO_SOUND
-void    S9xAPUWritePort(uint8_t port, uint8_t value);
-uint8_t S9xAPUReadPort(uint8_t port);
+void    S9xAPUWritePort(int32_t port, uint8_t value);
+uint8_t S9xAPUReadPort(int32_t port);
 void    S9xResetAPU(void);
 #endif
 

--- a/src/vfs/rom_flash_io.c
+++ b/src/vfs/rom_flash_io.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "esp_spi_flash.h"
+#include "esp_spiffs.h"
 
 
 const esp_partition_t* findRomPartition(const char* name) {

--- a/src/ws/oswan/WS.c
+++ b/src/ws/oswan/WS.c
@@ -11,6 +11,7 @@ $Rev: 71 $
 #include "WS.h"
 #include "WSApu.h"
 #include "WSInput.h"
+#include "WSFileio.h"
 #include "WSPdata.h"
 #include "WSBandai.h"
 #include "cpu/necintrf.h"


### PR DESCRIPTION
This PR cleans up build warnings across multiple emulator cores while keeping the resulting firmware build successful.

The main changes are:

Moves -fno-rtti out of the global build_flags and applies it only to C++ compilation via scripts/warning_flags.py. This keeps the flash-saving RTTI removal for C++ code, while avoiding invalid -fno-rtti warnings on C files where the flag has no effect.

Adds targeted warning flags for C/C++ where appropriate, without broadly hiding unrelated compiler output.

Fixes missing or ambiguous declarations in several cores, including MSX, PCE, WS/WSC, VFS, and SNES.

Cleans up macro redefinition warnings in Genesis, GBC, SMS, and GX4000 code.

Fixes const-correctness and function pointer table typing issues in NGP and other legacy C code.

Adjusts SNES APU stub declarations so disabled-sound builds still expose the expected prototypes.

Replaces a fragile strncat() usage in shared save-path generation with bounded memcpy() plus explicit termination.
