### PR TITLE
Converted selected 64-bit arithmetic to 32-bit operations across emulator display, timing, and file stream paths.

### DIFF
--- a/src/atari2600/a2600_display.cpp
+++ b/src/atari2600/a2600_display.cpp
@@ -283,14 +283,14 @@ static bool a2600_prepare_luts(const A2600RenderPlan& plan)
     }
 
     for (int x = 0; x < plan.dstW; ++x) {
-        s_xmap[x] = (int16_t)(plan.srcX0 + ((int64_t)x * plan.roiW) / plan.dstW);
+        s_xmap[x] = (int16_t)(plan.srcX0 + (x * plan.roiW) / plan.dstW);
     }
 
     for (int y = 0; y < plan.dstH; ++y) {
         if (plan.dstH == plan.roiH && !a2600FullScreen && s_use_ext) {
             s_ymap[y] = (int16_t)(plan.srcY0 + y);
         } else {
-            s_ymap[y] = (int16_t)(plan.srcY0 + ((int64_t)y * plan.roiH) / plan.dstH);
+            s_ymap[y] = (int16_t)(plan.srcY0 + (y * plan.roiH) / plan.dstH);
         }
     }
 

--- a/src/atari7800/a7800_video.cpp
+++ b/src/atari7800/a7800_video.cpp
@@ -202,11 +202,11 @@ static bool a7800_prepare_luts(const A7800RenderPlan& plan)
     }
 
     for (int x = 0; x < plan.dstW; ++x) {
-        s_xmap[x] = (int16_t)(plan.srcX0 + ((int64_t)x * plan.roiW) / plan.dstW);
+        s_xmap[x] = (int16_t)(plan.srcX0 + (x * plan.roiW) / plan.dstW);
     }
 
     for (int y = 0; y < plan.dstH; ++y) {
-        s_ymap[y] = (int16_t)(plan.srcY0 + ((int64_t)y * plan.roiH) / plan.dstH);
+        s_ymap[y] = (int16_t)(plan.srcY0 + (y * plan.roiH) / plan.dstH);
     }
 
     return true;

--- a/src/atari7800/core/libretro-common/streams/file_stream_transforms.c
+++ b/src/atari7800/core/libretro-common/streams/file_stream_transforms.c
@@ -112,7 +112,8 @@ int64_t rfread(void* buffer,
    if (!stream || (elem_size == 0) || (elem_count == 0))
       return 0;
 
-   return (filestream_read(stream, buffer, elem_size * elem_count) / elem_size);
+   int64_t bytes = filestream_read(stream, buffer, elem_size * elem_count);
+   return bytes <= 0 ? bytes : (int64_t)((size_t)bytes / elem_size);
 }
 
 char *rfgets(char *buffer, int maxCount, RFILE* stream)
@@ -137,7 +138,8 @@ int64_t rfwrite(void const* buffer,
    if (!stream || (elem_size == 0) || (elem_count == 0))
       return 0;
 
-   return (filestream_write(stream, buffer, elem_size * elem_count) / elem_size);
+   int64_t bytes = filestream_write(stream, buffer, elem_size * elem_count);
+   return bytes <= 0 ? bytes : (int64_t)((size_t)bytes / elem_size);
 }
 
 int rfputc(int character, RFILE * stream)

--- a/src/genesis/genesis_display.cpp
+++ b/src/genesis/genesis_display.cpp
@@ -50,8 +50,8 @@ static inline int clampi(int v, int lo, int hi) {
 /* Calculate centered Region of Interest */
 static inline void compute_centered_roi(int srcW, int srcH) {
   int zp = (genesisZoomPercent <= 0) ? 100 : genesisZoomPercent;
-  int roiW = (int)((int64_t)srcW * 100 / zp);
-  int roiH = (int)((int64_t)srcH * 100 / zp);
+  int roiW = (srcW * 100) / zp;
+  int roiH = (srcH * 100) / zp;
 
   // Bornes
   roiW = clampi(roiW, 16, srcW);
@@ -85,7 +85,7 @@ static inline void ensure_xmap_roi(int srcW, int dstW, int roiX0, int roiW) {
 
   // x -> roiX0 + x * roiW / dstW
   for (int x = 0; x < dstW; ++x) {
-    s_xmap[x] = (uint16_t)(roiX0 + (int)((int64_t)x * roiW / dstW));
+    s_xmap[x] = (uint16_t)(roiX0 + ((x * roiW) / dstW));
   }
 }
 
@@ -181,7 +181,7 @@ void display_task(void* arg) {
     int srcLineP1 = m.line + 1;
     int relP1     = srcLineP1 - s_roiY0;
     relP1 = clampi(relP1, 0, s_roiH);
-    int dstY_end  = g_viewY0 + (int)((int64_t)relP1 * g_viewH / s_roiH);
+    int dstY_end  = g_viewY0 + ((relP1 * g_viewH) / s_roiH);
 
     int linesToPush = dstY_end - prevDstY;
 

--- a/src/gx4000/gx4000_sound.cpp
+++ b/src/gx4000/gx4000_sound.cpp
@@ -109,7 +109,7 @@ static void update_effective_rate(void)
     if (elapsed < 1000U) return;
 
     uint32_t produced = s_statPushed - s_pushedAtWindow;
-    uint32_t measured = (uint32_t)((uint64_t)produced * 1000ULL / (uint64_t)elapsed);
+    uint32_t measured = (produced * 1000U) / elapsed;
     if (measured < 8000U)  measured = 8000U;
     if (measured > 22050U) measured = 22050U;
 

--- a/src/msx/msx_display.cpp
+++ b/src/msx/msx_display.cpp
@@ -99,9 +99,9 @@ static void rebuild_zoom_maps(int zp)
     const int roiX0 = (kSrcW - roiW) / 2;
     const int roiY0 = (kSrcH - roiH) / 2;
     for (int x = 0; x < kDstW; ++x)
-        g_host.xmapZoom[x] = (uint16_t)(roiX0 + (int64_t)x * roiW / kDstW);
+        g_host.xmapZoom[x] = (uint16_t)(roiX0 + (x * roiW) / kDstW);
     for (int y = 0; y < kDstH; ++y)
-        g_host.ymapZoom[y] = (uint16_t)(roiY0 + (int64_t)y * roiH / kDstH);
+        g_host.ymapZoom[y] = (uint16_t)(roiY0 + (y * roiH) / kDstH);
     g_host.zoomMapBuiltFor = zp;
 }
 

--- a/src/pce/pce-go/pce-go.c
+++ b/src/pce/pce-go/pce-go.c
@@ -324,7 +324,7 @@ void RunPCE(void)
 {
     running = true;
 
-    const uint64_t frameDurationUs = 1000000ULL / 60ULL; // 60 fps target
+    const uint32_t frameDurationUs = 1000000u / 60u; // 60 fps target
 
     uint64_t lastFpsTime   = esp_timer_get_time();
     uint32_t frameCounter  = 0;
@@ -357,7 +357,7 @@ void RunPCE(void)
 
         if (remain > 2000) {
             // gros reste
-            vTaskDelay(remain / 1000);
+            vTaskDelay((uint32_t)remain / 1000u);
         } else if (remain > 0) {
             // petit reste
             ets_delay_us((uint32_t)remain);

--- a/src/share/utils.cpp
+++ b/src/share/utils.cpp
@@ -3,6 +3,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <rom/ets_sys.h>
+#include <stdint.h>
 
 namespace share {
 
@@ -15,7 +16,8 @@ void sleep_until_us(uint64_t t_us)
 
         if (remain > 2000) {
             // big wait
-            vTaskDelay(pdMS_TO_TICKS((remain - 1000) / 1000));
+            const uint32_t wait_us = (remain > INT32_MAX) ? (uint32_t)INT32_MAX : (uint32_t)(remain - 1000);
+            vTaskDelay(pdMS_TO_TICKS(wait_us / 1000u));
         } else {
             // short busy wait
             ets_delay_us((uint32_t)remain);

--- a/src/sms/display.cpp
+++ b/src/sms/display.cpp
@@ -130,10 +130,10 @@ static inline void compute_common(bool fullscreenMode){
 
   // mapping (xmap / ymap)
   for (int x = 0; x < dstW; ++x)
-    xmap[x] = (uint16_t)(roiX0 + ((int64_t)x * roiW / dstW));
+    xmap[x] = (uint16_t)(roiX0 + ((x * roiW) / dstW));
 
   for (int y = 0; y < dstH; ++y)
-    ymap[y] = (uint16_t)(roiY0 + ((int64_t)y * roiH / dstH));
+    ymap[y] = (uint16_t)(roiY0 + ((y * roiH) / dstH));
 }
 
 void video_compute_scaler_full()   { compute_common(true);  }

--- a/src/ws/run_ws.cpp
+++ b/src/ws/run_ws.cpp
@@ -68,7 +68,7 @@ extern "C" void run_ws(const uint8_t* rom, size_t len, const char* rom_name, boo
     // Frame pacing (75Hz)
     next += frame_us;
     int64_t remain = (int64_t)next - (int64_t)esp_timer_get_time();
-    if (remain > 2000) vTaskDelay(remain / 1000 / portTICK_PERIOD_MS);
+    if (remain > 2000) vTaskDelay(((uint32_t)remain / 1000u) / portTICK_PERIOD_MS);
     else if (remain > 0) ets_delay_us((uint32_t)remain);
     else next = esp_timer_get_time();
   }

--- a/src/ws/ws_display.cpp
+++ b/src/ws/ws_display.cpp
@@ -95,10 +95,10 @@ static void ws_display_compute_scaler() {
 
   // LUT X/Y
   for (int dx = 0; dx < s_dstW; ++dx) {
-    s_xmap[dx] = (uint16_t)(roiX0 + ((int64_t)dx * roiW / s_dstW));
+    s_xmap[dx] = (uint16_t)(roiX0 + ((dx * roiW) / s_dstW));
   }
   for (int dy = 0; dy < s_dstH; ++dy) {
-    s_ymap[dy] = (uint16_t)(roiY0 + ((int64_t)dy * roiH / s_dstH));
+    s_ymap[dy] = (uint16_t)(roiY0 + ((dy * roiH) / s_dstH));
   }
 }
 


### PR DESCRIPTION
This PR reduces unnecessary 64-bit arithmetic in several emulator paths and replaces it with 32-bit calculations where the value ranges are already bounded by screen dimensions, frame timing intervals, or small buffer sizes.

The changes cover display scaler calculations for Atari 2600, Atari 7800, Genesis, MSX, SMS, and WonderSwan, plus selected timing/audio utility paths. This avoids pulling in heavier 64-bit math on the ESP32-S3 where it is not needed, while keeping the resulting coordinates and timing behavior equivalent for the current ranges used by the project.

