### PR TITLE
SMS/GG: Allocate cartridge SRAM lazily and flush saves before restart.

### DIFF
--- a/src/share/input.cpp
+++ b/src/share/input.cpp
@@ -10,6 +10,7 @@ static uint32_t s_lastInputUs = 0;
 uint32_t lastPadState = 0xFFFFFFFF;
 static const uint32_t INPUT_POLL_PERIOD_MS = 32;
 constexpr int64_t INPUT_POLL_PERIOD_US = 1000 * INPUT_POLL_PERIOD_MS;
+static share::BeforeRestartCallback s_beforeRestartCallback = nullptr;
 
 // I2C joypad type
 enum I2cPadType : uint8_t {
@@ -34,6 +35,16 @@ static constexpr uint8_t JOYSTICK1_ADDR = 0x52;
 
 namespace share
 {
+    void setBeforeRestartCallback(BeforeRestartCallback callback)
+    {
+        s_beforeRestartCallback = callback;
+    }
+
+    void clearBeforeRestartCallback()
+    {
+        s_beforeRestartCallback = nullptr;
+    }
+
    bool shouldPollInput()
     {
         uint32_t now = esp_timer_get_time();
@@ -57,6 +68,10 @@ namespace share
             prefs.begin("cardputer_emu", false);  // RW
             prefs.putBool("quit_game", true);
             prefs.end();
+
+            if (s_beforeRestartCallback) {
+                s_beforeRestartCallback();
+            }
             
             while (gameIsSaving()) {
                 delay(1); // wait for save to finish

--- a/src/share/input.h
+++ b/src/share/input.h
@@ -40,8 +40,12 @@ extern uint32_t lastPadState;
 
 namespace share
 {
+    typedef void (*BeforeRestartCallback)();
+
     bool shouldPollInput(); 
     void checkCommonInput(const Keyboard_Class::KeysState& status);
+    void setBeforeRestartCallback(BeforeRestartCallback callback);
+    void clearBeforeRestartCallback();
 
     // I2C PAD (M5Stack JoyV2 or Joystick v1.1)
     void detectI2cPad();

--- a/src/sms/run_sms.cpp
+++ b/src/sms/run_sms.cpp
@@ -14,6 +14,7 @@
 #include "sms/input.h"
 #include "sms/save.h"
 #include "share/emu_log_cpp.h"
+#include "share/input.h"
 
 // WARNING: The real bios is needed for Coleco emulation
 // It is not included in the repo for legal reasons
@@ -31,6 +32,11 @@ static uint8_t map_console_type(SmsConsoleMode mode)
   }
 }
 
+static void sms_flush_save_before_restart()
+{
+  sms_save_force_flush();
+}
+
 void run_sms(const uint8_t* romPtr, size_t romLen, SmsConsoleMode mode, const char* romName)
 {
   CardputerView display;
@@ -45,20 +51,20 @@ void run_sms(const uint8_t* romPtr, size_t romLen, SmsConsoleMode mode, const ch
   // Runtime buffers only: no core allocation at boot.
   uint8_t* videoBuf = (uint8_t*)heap_caps_aligned_alloc(
       32, 256 * 240, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT | MALLOC_CAP_DMA);
-  uint8_t* sram = nullptr;
-  if (needsSram) {
-    sram = (uint8_t*)heap_caps_aligned_alloc(
-        32, 0x8000, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-  }
 
-  if (!videoBuf || (needsSram && !sram)) {
-    EMU_LOG("SMS core alloc failed: video=%p sram=%p\n", videoBuf, sram);
+  if (!videoBuf) {
+    EMU_LOG("SMS core alloc failed: video=%p\n", videoBuf);
     free(videoBuf);
-    free(sram);
     return;
   }
 
-  if (sram) memset(sram, 0xFF, 0x8000);
+  if (needsSram) {
+    sms_save_prepare(romName, 0x8000);
+    share::setBeforeRestartCallback(sms_flush_save_before_restart);
+  } else {
+    sms_save_shutdown();
+    share::clearBeforeRestartCallback();
+  }
 
   sms.coleco_bios = (mode == SMS_MODE_COLECO)
       ? (uint8_t*)ColecoVision_BIOS
@@ -66,7 +72,7 @@ void run_sms(const uint8_t* romPtr, size_t romLen, SmsConsoleMode mode, const ch
 
   // Mapping structures core
   sms.dummy = videoBuf;
-  sms.sram  = sram;
+  sms.sram  = nullptr;
 
   bitmap.width  = 256;
   bitmap.height = 192;
@@ -88,25 +94,21 @@ void run_sms(const uint8_t* romPtr, size_t romLen, SmsConsoleMode mode, const ch
   if (!z80_allocate_flag_tables()) {
     EMU_LOG("SMS Z80 alloc failed\n");
     free(videoBuf);
-    free(sram);
+    sms_save_shutdown();
+    share::clearBeforeRestartCallback();
     sms.coleco_bios = nullptr;
     return;
   }
   if (!sms_init_ram()) {
     EMU_LOG("SMS WRAM alloc failed\n");
     free(videoBuf);
-    free(sram);
+    sms_save_shutdown();
+    share::clearBeforeRestartCallback();
     sms.coleco_bios = nullptr;
     return;
   }
   emu_system_init(22050);
   system_reset();
-
-  // Save
-  if (sram) {
-    sms_save_init(romName, sram, 0x8000);
-    sms_save_load();
-  }
 
   // Display
   sms_display_init(); 

--- a/src/sms/save.cpp
+++ b/src/sms/save.cpp
@@ -6,8 +6,9 @@
 #include <sys/stat.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_heap_caps.h"
 #include <unistd.h>
-#include "share/game_save.h"  
+#include "share/game_save.h"
 #include "share/emu_log_cpp.h"
 
 static uint8_t* g_sram = NULL;
@@ -16,27 +17,22 @@ static char*    g_save_path = nullptr;
 static uint32_t g_crc_last = 0;
 static TickType_t g_next_check = 0;
 static TickType_t g_next_allowed_write = 0;
-static TaskHandle_t g_save_task = nullptr;
-static uint8_t* g_sram_shadow = nullptr;
-static volatile bool g_flush_req = false;     // ask for flush
-static volatile bool g_check_req = false;     // ask for check (CRC)
+static bool     g_owns_sram = false;
+static bool     g_alloc_failed_logged = false;
 
-static void ensure_dir(void){ 
-  mkdir("/sd/sms_saves", 0777); 
+static void ensure_dir(void)
+{
+  mkdir("/sd/sms_saves", 0777);
 }
 
-static bool flush_now(void){
+static bool flush_now(void)
+{
   if (!g_sram || !g_sram_len) return false;
+  if (!g_save_path) return false;
 
   if (share::gameSaveIsTrivialSram(g_sram, g_sram_len)) {
     EMU_LOG("SMS save: skip trivial SRAM, no write.\n");
-    return false; 
-  }
-
-  const uint8_t* src = g_sram;
-  if (g_sram_shadow) {
-    memcpy(g_sram_shadow, g_sram, g_sram_len);
-    src = g_sram_shadow;
+    return false;
   }
 
   share::setGameIsSaving(true);
@@ -45,123 +41,115 @@ static bool flush_now(void){
 
   char tmp_path[PATH_MAX];
   snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", g_save_path);
-  tmp_path[sizeof(tmp_path)-1] = '\0';
+  tmp_path[sizeof(tmp_path) - 1] = '\0';
 
-  // Write to temp file
   FILE* f = fopen(tmp_path, "wb");
   if (!f) {
     EMU_LOG("SMS save: fopen tmp fail %s\n", tmp_path);
+    share::setGameIsSaving(false);
     return false;
   }
   setvbuf(f, NULL, _IONBF, 0);
 
-  size_t w = fwrite(src, 1, g_sram_len, f);
+  size_t w = 0;
+  uint8_t chunk[512];
+  while (w < g_sram_len) {
+    size_t n = g_sram_len - w;
+    if (n > sizeof(chunk)) n = sizeof(chunk);
+    memcpy(chunk, g_sram + w, n);
+    size_t part = fwrite(chunk, 1, n, f);
+    w += part;
+    if (part != n) break;
+  }
   fflush(f);
   fsync(fileno(f));
   fclose(f);
 
   if (w != g_sram_len) {
     EMU_LOG("SMS save: short write %u/%u to %s\n",
-           (unsigned)w, (unsigned)g_sram_len, tmp_path);
+            (unsigned)w, (unsigned)g_sram_len, tmp_path);
+    share::setGameIsSaving(false);
     return false;
   }
 
-  // Unlink + rename
   unlink(g_save_path);
   if (rename(tmp_path, g_save_path) != 0) {
     EMU_LOG("SMS save: rename failed %s -> %s\n", tmp_path, g_save_path);
+    share::setGameIsSaving(false);
     return false;
   }
 
   EMU_LOG("SMS save: wrote %u/%u -> %s \n",
-         (unsigned)w, (unsigned)g_sram_len, g_save_path);
-         
+          (unsigned)w, (unsigned)g_sram_len, g_save_path);
+
   share::setGameIsSaving(false);
   return true;
 }
 
-static void SaveTask(void*){
-  for(;;){
-    // sleep until notified
-    ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(CHECK_MS));
-
-    bool do_check = g_check_req; g_check_req = false;
-    bool do_flush = g_flush_req; g_flush_req = false;
-
-    TickType_t now = xTaskGetTickCount();
-
-    if (do_check) {
-      uint32_t crc = share::gameSaveCrc32Update(0, g_sram, g_sram_len);
-      if (crc != g_crc_last && now >= g_next_allowed_write){
-        g_crc_last = crc;
-
-        if (!share::gameSaveIsTrivialSram(g_sram, g_sram_len)) {
-          do_flush = true;
-        } else {
-          EMU_LOG("SMS save: trivial after change, skip write.\n");
-        }
-      }
-    }
-
-    // flush if requested and allowed
-    if (do_flush && now >= g_next_allowed_write) {
-      bool ok = flush_now();
-      if (ok) {
-        // save OK
-        g_next_allowed_write = xTaskGetTickCount() + pdMS_TO_TICKS(GAP_MS);
-      } else {
-        // failed, dont delay next attempt
-        g_crc_last = 0xFFFFFFFFu;
-        EMU_LOG("SMS save: flush failed, will retry on next tick.\n");
-      }
-    }
-  }
-}
-
-void sms_save_init(const char* romName, uint8_t* sramPtr, size_t sramLen){
+void sms_save_prepare(const char* romName, size_t sramLen)
+{
   if (!g_save_path) {
     g_save_path = (char*)malloc(PATH_MAX);
     if (!g_save_path) abort();
   }
-  g_sram = sramPtr;
+
   g_sram_len = sramLen;
   share::gameSaveBuildPath(g_save_path, PATH_MAX, "/sd/sms_saves", romName, "rom.sms");
-  g_crc_last = (g_sram && g_sram_len) ? share::gameSaveCrc32Update(0, g_sram, g_sram_len) : 0;
+  g_crc_last = 0;
   g_next_check = g_next_allowed_write = 0;
-
-  // snapshot SRAM
-  if (!g_sram_shadow && g_sram_len) {
-    g_sram_shadow = (uint8_t*)malloc(g_sram_len);
-    if (!g_sram_shadow) {
-      EMU_LOG("SMS save: no shadow buffer, will write live.\n");
-    }
-  }
-
-  // launch save task
-  if (!g_save_task) {
-    xTaskCreatePinnedToCore(SaveTask, "SaveTask", 4096, nullptr, 2, &g_save_task, 0);
-  }
+  g_alloc_failed_logged = false;
 }
 
-void sms_save_load(void){
+uint8_t* sms_save_ensure_sram(void)
+{
+  if (g_sram) return g_sram;
+  if (!g_save_path || !g_sram_len) return nullptr;
+
+  g_sram = (uint8_t*)heap_caps_aligned_alloc(
+      32, g_sram_len, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+  if (!g_sram) {
+    if (!g_alloc_failed_logged) {
+      EMU_LOG("SMS save: SRAM alloc failed (%u bytes), save RAM disabled.\n",
+              (unsigned)g_sram_len);
+      g_alloc_failed_logged = true;
+    }
+    return nullptr;
+  }
+
+  g_owns_sram = true;
+  memset(g_sram, 0xFF, g_sram_len);
+  EMU_LOG("SMS save: SRAM allocated lazily: %u bytes\n", (unsigned)g_sram_len);
+  sms_save_load();
+  return g_sram;
+}
+
+void sms_save_init(const char* romName, uint8_t* sramPtr, size_t sramLen)
+{
+  sms_save_prepare(romName, sramLen);
+  g_sram = sramPtr;
+  g_owns_sram = false;
+  g_crc_last = (g_sram && g_sram_len) ? share::gameSaveCrc32Update(0, g_sram, g_sram_len) : 0;
+}
+
+void sms_save_load(void)
+{
   if (!g_sram || !g_sram_len) return;
   memset(g_sram, 0xFF, g_sram_len);
 
-  ensure_dir(); 
+  ensure_dir();
 
   char tmp_path[PATH_MAX];
   snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", g_save_path);
-  tmp_path[sizeof(tmp_path)-1] = '\0';
+  tmp_path[sizeof(tmp_path) - 1] = '\0';
 
   const char* loaded_path = g_save_path;
 
-  // Try to load .sav
   FILE* f = fopen(g_save_path, "rb");
   if (!f) {
-    // Try to load .tmp
     f = fopen(tmp_path, "rb");
     if (!f) {
       EMU_LOG("SMS load: no save, %s nor %s\n", g_save_path, tmp_path);
+      g_crc_last = share::gameSaveCrc32Update(0, g_sram, g_sram_len);
       return;
     }
 
@@ -178,38 +166,53 @@ void sms_save_load(void){
   g_crc_last = share::gameSaveCrc32Update(0, g_sram, g_sram_len);
 
   EMU_LOG("SMS load: read %u/%u from %s\n",
-         (unsigned)n, (unsigned)g_sram_len, loaded_path);
+          (unsigned)n, (unsigned)g_sram_len, loaded_path);
 }
 
-void sms_save_tick(void){
+void sms_save_tick(void)
+{
   if (!g_sram || !g_sram_len) return;
+
   TickType_t now = xTaskGetTickCount();
   if (now < g_next_check) return;
   g_next_check = now + pdMS_TO_TICKS(CHECK_MS);
 
-  g_check_req = true;
-  if (g_save_task) xTaskNotifyGive(g_save_task);
+  uint32_t crc = share::gameSaveCrc32Update(0, g_sram, g_sram_len);
+  if (crc == g_crc_last) return;
+
+  g_crc_last = crc;
+  if (share::gameSaveIsTrivialSram(g_sram, g_sram_len)) {
+    EMU_LOG("SMS save: trivial after change, skip write.\n");
+    return;
+  }
+
+  if (now >= g_next_allowed_write) {
+    if (flush_now()) {
+      g_next_allowed_write = xTaskGetTickCount() + pdMS_TO_TICKS(GAP_MS);
+    } else {
+      g_crc_last = 0xFFFFFFFFu;
+      EMU_LOG("SMS save: flush failed, will retry on next tick.\n");
+    }
+  }
 }
 
-void sms_save_force_flush(void){
+void sms_save_force_flush(void)
+{
   flush_now();
 }
 
-void sms_save_shutdown(void){
-  if (g_save_task) {
-    vTaskDelete(g_save_task);
-    g_save_task = nullptr;
-  }
-
-  free(g_sram_shadow);
-  g_sram_shadow = nullptr;
-
+void sms_save_shutdown(void)
+{
   free(g_save_path);
   g_save_path = nullptr;
+
+  if (g_owns_sram && g_sram) {
+    heap_caps_free(g_sram);
+  }
 
   g_sram = nullptr;
   g_sram_len = 0;
   g_crc_last = 0;
-  g_flush_req = false;
-  g_check_req = false;
+  g_owns_sram = false;
+  g_alloc_failed_logged = false;
 }

--- a/src/sms/save.h
+++ b/src/sms/save.h
@@ -6,6 +6,8 @@
 extern "C" {
 #endif
 
+void sms_save_prepare(const char* romName, size_t sramLen);
+uint8_t* sms_save_ensure_sram(void);
 void sms_save_init(const char* romName, uint8_t* sramPtr, size_t sramLen);
 void sms_save_load(void);
 void sms_save_tick(void);

--- a/src/sms/smsplus/sms.c
+++ b/src/sms/smsplus/sms.c
@@ -1,5 +1,6 @@
 
 #include "shared.h"
+#include "sms/save.h"
 void ym2413_write(int chip, int offset, int data);
 
 /* SMS context */
@@ -462,12 +463,28 @@ void sms_mapper_w(int address, int data)
         case 0:
             if(data & 8)
             {
-                sms.save = 1;
-                /* Page in ROM */
-                cpu_readmap[4]  = &sms.sram[(data & 4) ? 0x4000 : 0x0000];
-                cpu_readmap[5]  = &sms.sram[(data & 4) ? 0x6000 : 0x2000];
-                cpu_writemap[4] = &sms.sram[(data & 4) ? 0x4000 : 0x0000];
-                cpu_writemap[5] = &sms.sram[(data & 4) ? 0x6000 : 0x2000];
+                if(!sms.sram)
+                {
+                    sms.sram = sms_save_ensure_sram();
+                }
+
+                if(sms.sram)
+                {
+                    sms.save = 1;
+                    /* Page in cartridge SRAM */
+                    cpu_readmap[4]  = &sms.sram[(data & 4) ? 0x4000 : 0x0000];
+                    cpu_readmap[5]  = &sms.sram[(data & 4) ? 0x6000 : 0x2000];
+                    cpu_writemap[4] = &sms.sram[(data & 4) ? 0x4000 : 0x0000];
+                    cpu_writemap[5] = &sms.sram[(data & 4) ? 0x6000 : 0x2000];
+                }
+                else
+                {
+                    sms.save = 0;
+                    cpu_readmap[4]  = sms.dummy;
+                    cpu_readmap[5]  = sms.dummy;
+                    cpu_writemap[4] = sms.dummy;
+                    cpu_writemap[5] = sms.dummy;
+                }
             }
             else
             {


### PR DESCRIPTION
This change reduces the baseline RAM cost of the SMS/GG core by avoiding an unconditional 32 KB cartridge SRAM allocation at startup.

Previously, SMS/GG reserved SRAM even for games that never enabled or used cartridge-backed RAM. The new flow prepares the save path up front, but only allocates the 32 KB SRAM buffer when the mapper actually pages SRAM in. If allocation fails, the mapper safely falls back to dummy memory instead of crashing or writing through an invalid pointer.

The save path is also simplified: saves are checked and flushed synchronously from the regular tick path, and a pre-restart callback forces a final flush before reboot. This avoids keeping an additional permanent save shadow buffer in memory while still preserving SRAM data when the user exits or restarts.

Overall, this keeps SMS/GG save support intact while freeing memory for games that do not need cartridge SRAM.