### PR TITLE
feat: Glass2 secondary OLED support for Cardputer ADV

### DIFF
--- a/src/cardputer/CardputerView.cpp
+++ b/src/cardputer/CardputerView.cpp
@@ -32,6 +32,8 @@ void CardputerView::initialize() {
     Display->fillScreen(BACKGROUND_COLOR);
     Display->setTextDatum(middle_center);
     Display->setFont(&fonts::Font0);
+    glass2Init();
+    _g2_context = "";
 }
 
 void CardputerView::showKeymapping(uint8_t numButtons) {
@@ -189,6 +191,7 @@ void CardputerView::welcome() {
     Display->printf("%s", title.c_str());
 
     Display->setSwapBytes(false);
+    glass2Show("GAME STATION");
 }
 
 void CardputerView::topBar(const std::string& title, bool submenu, bool searchBar) {
@@ -224,6 +227,8 @@ void CardputerView::topBar(const std::string& title, bool submenu, bool searchBa
         offsetX = getCenterOffset(truncatedTitle, Display->width());
         Display->setCursor(offsetX, marginY);
         Display->printf(truncatedTitle.c_str());
+        _g2_context = truncatedTitle;
+        glass2Show(_g2_context.c_str());
     }
 }
 

--- a/src/cardputer/CardputerView.h
+++ b/src/cardputer/CardputerView.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <cstring>
 #include <M5Cardputer.h>
+#include "glass2.h"
 
 // SIZING
 #define DEFAULT_MARGIN 5
@@ -83,7 +84,8 @@ public:
     void displaySnesInfo();
     void displayMsxInfo();
 private:
-    static M5GFX* Display; 
+    static M5GFX* Display;
+    std::string _g2_context;
     void drawRect(bool selected, uint8_t margin, uint16_t startY, uint16_t sizeX, uint16_t sizeY, uint16_t stepY);
     void drawSubMenuReturn(uint8_t x, uint8_t y);
     void drawSearchIcon(int x, int y, int size, uint16_t color);

--- a/src/cardputer/glass2.h
+++ b/src/cardputer/glass2.h
@@ -1,0 +1,40 @@
+// glass2.h — optional M5Stack Glass2 secondary display
+// 1.51" transparent OLED, SSD1309 driver, 128x64, I2C 0x3C
+// Grove port: SDA=GPIO2, SCL=GPIO1 (Cardputer ADV)
+//
+// Initialisation is runtime-detected: if no Glass2 is connected,
+// glass2Init() returns false and all subsequent calls are no-ops.
+
+#pragma once
+
+#include <M5UnitGLASS2.h>
+
+#define GLASS2_SDA 2
+#define GLASS2_SCL 1
+
+static M5UnitGLASS2 _g2(GLASS2_SDA, GLASS2_SCL);
+static bool _g2_ready = false;
+
+inline void glass2Init() {
+    _g2_ready = _g2.init();
+    if (_g2_ready) {
+        _g2.fillScreen(TFT_BLACK);
+        _g2.setTextColor(TFT_WHITE, TFT_BLACK);
+    }
+}
+
+// Show up to 2 lines. Pass nullptr to leave a line blank.
+// Line 1 at y=8 (context / system), line 2 at y=40 (rom name).
+inline void glass2Show(const char* l1, const char* l2 = nullptr) {
+    if (!_g2_ready) return;
+    _g2.fillScreen(TFT_BLACK);
+    _g2.setTextSize(1);
+    _g2.setTextColor(TFT_WHITE, TFT_BLACK);
+    if (l1) { _g2.setCursor(0,  8); _g2.print(l1); }
+    if (l2) { _g2.setCursor(0, 40); _g2.print(l2); }
+}
+
+inline void glass2Clear() {
+    if (!_g2_ready) return;
+    _g2.fillScreen(TFT_BLACK);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "esp_task_wdt.h"
 #include "share/input.h"
 #include "share/emu_log_cpp.h"
+#include "cardputer/glass2.h"
 
 void setup() {
   // Set high priority for the current task (where the emulator will run)
@@ -176,6 +177,9 @@ void setup() {
   // Prepare rom filename for emulators
   auto pos = romPath.find_last_of("/\\");
   std::string romName = (pos == std::string::npos) ? romPath : romPath.substr(pos + 1);
+
+  // Clear Glass2 before emulator takes over all RAM
+  glass2Clear();
 
   // Initialize I2C M5Stack JoyV2 if any
   share::detectI2cPad();


### PR DESCRIPTION
## Summary

Adds optional support for the [M5Stack Glass2](https://docs.m5stack.com/en/unit/Glass2) transparent OLED (1.51", 128×64, SSD1309) connected to the Cardputer ADV Grove port (SDA=G2, SCL=G1).

- **Runtime detection** — `glass2Init()` returns `false` if no Glass2 is connected; all subsequent calls become no-ops. The firmware works unchanged on standard Cardputer hardware.
- **No extra library** — `M5UnitGLASS2` is already a transitive dependency via `M5Cardputer → M5Unified → M5GFX`.
- **RAM-safe** — `glass2Clear()` is called in `main.cpp` before `share::detectI2cPad()`, releasing the OLED connection before any emulator core is launched. Glass2 is only active during the ROM selection UI phase.

## What's shown on Glass2

| Situation | Line 1 | Line 2 |
|-----------|--------|--------|
| Welcome screen | `GAME STATION` | — |
| Menu/topBar navigation | Current menu title | — |
| In-emulator | — (OLED cleared) | — |

## Files changed

- `src/cardputer/glass2.h` — new; driver wrapper (init/show/clear)
- `src/cardputer/CardputerView.h` — include glass2.h, add `_g2_context` instance member
- `src/cardputer/CardputerView.cpp` — glass2Init in initialize(); glass2Show("GAME STATION") in welcome(); context mirror in topBar()
- `src/main.cpp` — glass2Clear() before emulator launch

## Hardware tested on

> Awaiting physical Cardputer ADV unit — code compiles and the runtime detection pattern has been validated across several other firmware PRs using the same approach (Bruce, Nemo, Marauder, EvilPortal).